### PR TITLE
44/ Configure output_type_id from config

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubData
 Title: Tools for accessing and working with hubverse data
-Version: 1.0.0
+Version: 1.1.0
 Authors@R: 
     c(person("Anna", "Krystalli", , "annakrystalli@googlemail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2378-4915")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # hubData 1.1.0
 
-* Add `"from_config"` option to the `output_type_id_datatype` argument in `create_hub_schema()`, `coerce_to_hub_schema()` and `connect_hub()`. This allows users to set the `output_type_id` column data type from the `tasks.json` `output_type_id_datatype` property. (#44)
+* Add `"from_config"` option to the `output_type_id_datatype` argument in `create_hub_schema()`, `coerce_to_hub_schema()` and `connect_hub()`. This allows users to set the hub level `output_type_id` column data type through the `tasks.json` `output_type_id_datatype` property introduced in schema version v3.0.1. (#44)
 
 # hubData 1.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hubData 1.1.0
+
+* Add `"from_config"` option to the `output_type_id_datatype` argument in `create_hub_schema()`, `coerce_to_hub_schema()` and `connect_hub()`. This allows users to set the `output_type_id` column data type from the `tasks.json` `output_type_id_datatype` property. (#44)
+
 # hubData 1.0.0
 
 * Breaking change: `expand_model_out_val_grid()` and `create_model_out_submit_tmpl()` are now defunct. These functions have been moved to `hubValidations` and replaced by `hubValidations::expand_model_out_grid()` and `hubValidations::submission_tmpl()`, respectively. The old functions will now fail if called and will be removed in a future release.

--- a/R/coerce_to_hub_schema.R
+++ b/R/coerce_to_hub_schema.R
@@ -11,11 +11,17 @@
 #' @describeIn coerce_to_hub_schema coerce columns to hub schema data types.
 #' @export
 coerce_to_hub_schema <- function(tbl, config_tasks, skip_date_coercion = FALSE,
-                                 as_arrow_table = FALSE) {
+                                 as_arrow_table = FALSE,
+                                 output_type_id_datatype = c(
+                                   "from_config", "auto", "character",
+                                   "double", "integer",
+                                   "logical", "Date"
+                                 )) {
   tbl_schema <- create_hub_schema(
     config_tasks,
     partitions = NULL,
-    r_schema = TRUE
+    r_schema = TRUE,
+    output_type_id_datatype = output_type_id_datatype
   )
   tbl_schema <- tbl_schema[names(tbl)]
 

--- a/R/connect_hub.R
+++ b/R/connect_hub.R
@@ -119,9 +119,9 @@ connect_hub.default <- function(hub_path,
     dataset <- list()
   } else {
     dataset <- open_hub_datasets(
-      model_output_dir,
-      file_format,
-      config_tasks,
+      model_output_dir= model_output_dir,
+      file_format = file_format,
+      config_tasks = config_tasks,
       output_type_id_datatype = output_type_id_datatype,
       partitions = partitions
     )
@@ -194,9 +194,9 @@ connect_hub.SubTreeFileSystem <- function(hub_path,
     dataset <- list()
   } else {
     dataset <- open_hub_datasets(
-      model_output_dir,
-      file_format,
-      config_tasks,
+      model_output_dir = model_output_dir,
+      file_format = file_format,
+      config_tasks = config_tasks,
       output_type_id_datatype = output_type_id_datatype,
       partitions = partitions
     )
@@ -287,9 +287,9 @@ open_hub_datasets <- function(model_output_dir,
                               call = rlang::caller_env()) {
   if (length(file_format) == 1L) {
     open_hub_dataset(
-      model_output_dir,
-      file_format,
-      config_tasks,
+      model_output_dir = model_output_dir,
+      file_format = file_format,
+      config_tasks = config_tasks,
       output_type_id_datatype,
       partitions = partitions
     )
@@ -297,10 +297,10 @@ open_hub_datasets <- function(model_output_dir,
     cons <- purrr::map(
       file_format,
       ~ open_hub_dataset(
-        model_output_dir,
-        .x,
-        config_tasks,
-        output_type_id_datatype,
+        model_output_dir = model_output_dir,
+        file_format = .x,
+        config_tasks = config_tasks,
+        output_type_id_datatype = output_type_id_datatype,
         partitions = partitions
       )
     )

--- a/R/connect_hub.R
+++ b/R/connect_hub.R
@@ -119,7 +119,7 @@ connect_hub.default <- function(hub_path,
     dataset <- list()
   } else {
     dataset <- open_hub_datasets(
-      model_output_dir= model_output_dir,
+      model_output_dir = model_output_dir,
       file_format = file_format,
       config_tasks = config_tasks,
       output_type_id_datatype = output_type_id_datatype,

--- a/R/connect_hub.R
+++ b/R/connect_hub.R
@@ -71,7 +71,7 @@
 connect_hub <- function(hub_path,
                         file_format = c("csv", "parquet", "arrow"),
                         output_type_id_datatype = c(
-                          "auto", "character",
+                          "from_config", "auto", "character",
                           "double", "integer",
                           "logical", "Date"
                         ),
@@ -84,7 +84,7 @@ connect_hub <- function(hub_path,
 connect_hub.default <- function(hub_path,
                                 file_format = c("csv", "parquet", "arrow"),
                                 output_type_id_datatype = c(
-                                  "auto", "character",
+                                  "from_config", "auto", "character",
                                   "double", "integer",
                                   "logical", "Date"
                                 ),
@@ -157,6 +157,7 @@ connect_hub.default <- function(hub_path,
 connect_hub.SubTreeFileSystem <- function(hub_path,
                                           file_format = c("csv", "parquet", "arrow"),
                                           output_type_id_datatype = c(
+                                            "from_config",
                                             "auto",
                                             "character",
                                             "double",
@@ -232,6 +233,7 @@ open_hub_dataset <- function(model_output_dir,
                              file_format = c("csv", "parquet", "arrow"),
                              config_tasks,
                              output_type_id_datatype = c(
+                               "from_config",
                                "auto", "character",
                                "double", "integer",
                                "logical", "Date"
@@ -276,6 +278,7 @@ open_hub_datasets <- function(model_output_dir,
                               file_format = c("csv", "parquet", "arrow"),
                               config_tasks,
                               output_type_id_datatype = c(
+                                "from_config",
                                 "auto", "character",
                                 "double", "integer",
                                 "logical", "Date"

--- a/R/create_hub_schema.R
+++ b/R/create_hub_schema.R
@@ -43,6 +43,8 @@ create_hub_schema <- function(config_tasks,
     output_type_id_datatype <- config_tasks$output_type_id_datatype
     if (is.null(output_type_id_datatype)) {
       output_type_id_datatype <- "auto"
+    } else {
+      output_type_id_datatype <- rlang::arg_match(output_type_id_datatype)
     }
   }
 
@@ -189,7 +191,7 @@ get_output_type_id_type <- function(config_tasks) {
     # id values, create zero length vectors of sample output type id types
     # using the function specified by output_type_id_params type.
     # Get the appropriate function using `get`.
-    purrr::map(~get(.x)()) %>%
+    purrr::map(~ get(.x)()) %>%
     unlist()
 
   get_data_type(c(values, sample_values))

--- a/man/coerce_to_hub_schema.Rd
+++ b/man/coerce_to_hub_schema.Rd
@@ -9,7 +9,9 @@ coerce_to_hub_schema(
   tbl,
   config_tasks,
   skip_date_coercion = FALSE,
-  as_arrow_table = FALSE
+  as_arrow_table = FALSE,
+  output_type_id_datatype = c("from_config", "auto", "character", "double", "integer",
+    "logical", "Date")
 )
 
 coerce_to_character(tbl, as_arrow_table = FALSE)
@@ -24,6 +26,20 @@ config file created using function \code{\link[hubUtils:read_config]{hubUtils::r
 especially for larger \code{tbl}s.}
 
 \item{as_arrow_table}{Logical. Whether to return an arrow table. Defaults to \code{FALSE}.}
+
+\item{output_type_id_datatype}{character string. One of \code{"from_config"}, \code{"auto"},
+\code{"character"}, \code{"double"}, \code{"integer"}, \code{"logical"}, \code{"Date"}.
+Defaults to \code{"from_config"} which uses the setting in the \code{output_type_id_datatype}
+property in the \code{tasks.json} config file if available. If the property is
+not set in the config, the argument falls back to \code{"auto"} which determines
+the  \code{output_type_id} data type automatically from the \code{tasks.json}
+config file as the simplest data type required to represent all output
+type ID values across all output types in the hub.
+Other data type values can be used to override automatic determination.
+Note that attempting to coerce \code{output_type_id} to a data type that is
+not valid for the data (e.g. trying to coerce\code{"character"} values to
+\code{"double"}) will likely result in an error or potentially unexpected
+behaviour so use with care.}
 }
 \value{
 \code{tbl} with column data types coerced to hub schema data types or character.

--- a/man/connect_hub.Rd
+++ b/man/connect_hub.Rd
@@ -8,8 +8,8 @@
 connect_hub(
   hub_path,
   file_format = c("csv", "parquet", "arrow"),
-  output_type_id_datatype = c("auto", "character", "double", "integer", "logical",
-    "Date"),
+  output_type_id_datatype = c("from_config", "auto", "character", "double", "integer",
+    "logical", "Date"),
   partitions = list(model_id = arrow::utf8())
 )
 
@@ -38,14 +38,19 @@ For connection to a fully configured hub, accessed through \code{hub_path},
 If supplied, it will override hub configuration setting. Multiple formats can
 be supplied to \code{connect_hub} but only a single file format can be supplied to \code{connect_mod_out}.}
 
-\item{output_type_id_datatype}{character string. One of \code{"auto"}, \code{"character"},
-\code{"double"}, \code{"integer"}, \code{"logical"}, \code{"Date"}. Defaults to \code{"auto"} indicating
-that \code{output_type_id} will be determined automatically from the \code{tasks.json}
-config file. Other data type values can be used to override automatic determination.
-Note that attempting to coerce \code{output_type_id} to a data type that is not possible
-(e.g. trying to coerce to \code{"double"} when the data contains \code{"character"} values)
-will likely result in an error or potentially unexpected behaviour so use with
-care.}
+\item{output_type_id_datatype}{character string. One of \code{"from_config"}, \code{"auto"},
+\code{"character"}, \code{"double"}, \code{"integer"}, \code{"logical"}, \code{"Date"}.
+Defaults to \code{"from_config"} which uses the setting in the \code{output_type_id_datatype}
+property in the \code{tasks.json} config file if available. If the property is
+not set in the config, the argument falls back to \code{"auto"} which determines
+the  \code{output_type_id} data type automatically from the \code{tasks.json}
+config file as the simplest data type required to represent all output
+type ID values across all output types in the hub.
+Other data type values can be used to override automatic determination.
+Note that attempting to coerce \code{output_type_id} to a data type that is
+not valid for the data (e.g. trying to coerce\code{"character"} values to
+\code{"double"}) will likely result in an error or potentially unexpected
+behaviour so use with care.}
 
 \item{partitions}{a named list specifying the arrow data types of any
 partitioning column.}

--- a/man/create_hub_schema.Rd
+++ b/man/create_hub_schema.Rd
@@ -7,8 +7,8 @@
 create_hub_schema(
   config_tasks,
   partitions = list(model_id = arrow::utf8()),
-  output_type_id_datatype = c("auto", "character", "double", "integer", "logical",
-    "Date"),
+  output_type_id_datatype = c("from_config", "auto", "character", "double", "integer",
+    "logical", "Date"),
   r_schema = FALSE
 )
 }
@@ -19,14 +19,19 @@ config file created using function \code{\link[hubUtils:read_config]{hubUtils::r
 \item{partitions}{a named list specifying the arrow data types of any
 partitioning column.}
 
-\item{output_type_id_datatype}{character string. One of \code{"auto"}, \code{"character"},
-\code{"double"}, \code{"integer"}, \code{"logical"}, \code{"Date"}. Defaults to \code{"auto"} indicating
-that \code{output_type_id} will be determined automatically from the \code{tasks.json}
-config file. Other data type values can be used to override automatic determination.
-Note that attempting to coerce \code{output_type_id} to a data type that is not possible
-(e.g. trying to coerce to \code{"double"} when the data contains \code{"character"} values)
-will likely result in an error or potentially unexpected behaviour so use with
-care.}
+\item{output_type_id_datatype}{character string. One of \code{"from_config"}, \code{"auto"},
+\code{"character"}, \code{"double"}, \code{"integer"}, \code{"logical"}, \code{"Date"}.
+Defaults to \code{"from_config"} which uses the setting in the \code{output_type_id_datatype}
+property in the \code{tasks.json} config file if available. If the property is
+not set in the config, the argument falls back to \code{"auto"} which determines
+the  \code{output_type_id} data type automatically from the \code{tasks.json}
+config file as the simplest data type required to represent all output
+type ID values across all output types in the hub.
+Other data type values can be used to override automatic determination.
+Note that attempting to coerce \code{output_type_id} to a data type that is
+not valid for the data (e.g. trying to coerce\code{"character"} values to
+\code{"double"}) will likely result in an error or potentially unexpected
+behaviour so use with care.}
 
 \item{r_schema}{Logical. If \code{FALSE} (default), return an \code{\link[arrow:schema]{arrow::schema()}} object.
 If \code{TRUE}, return a character vector of R data types.}

--- a/tests/testthat/test-create_hub_schema.R
+++ b/tests/testthat/test-create_hub_schema.R
@@ -97,3 +97,33 @@ test_that("create_hub_schema works with sample output types", {
     "forecast_date: date32[day]\ntarget: string\nhorizon: int32\nlocation: string\noutput_type: string\noutput_type_id: string\nvalue: double\nmodel_id: string"
   )
 })
+
+test_that("create_hub_schema works with config output_type_id_datatype", {
+  config_tasks_otid_datatype <- hubUtils::read_config_file(
+    testthat::test_path(
+      "testdata",
+      "configs",
+      "tasks-set-otid-datatype.json"
+    )
+  )
+  expect_equal(
+    create_hub_schema(
+      config_tasks_otid_datatype
+      )$GetFieldByName("output_type_id")$ToString(),
+    "output_type_id: string"
+  )
+  expect_equal(
+    create_hub_schema(
+      config_tasks_otid_datatype,
+      output_type_id_datatype = "double"
+    )$GetFieldByName("output_type_id")$ToString(),
+    "output_type_id: double"
+  )
+  expect_equal(
+    create_hub_schema(
+      config_tasks_otid_datatype,
+      output_type_id_datatype = "auto"
+    )$GetFieldByName("output_type_id")$ToString(),
+    "output_type_id: double"
+  )
+})

--- a/tests/testthat/test-create_hub_schema.R
+++ b/tests/testthat/test-create_hub_schema.R
@@ -109,7 +109,7 @@ test_that("create_hub_schema works with config output_type_id_datatype", {
   expect_equal(
     create_hub_schema(
       config_tasks_otid_datatype
-      )$GetFieldByName("output_type_id")$ToString(),
+    )$GetFieldByName("output_type_id")$ToString(),
     "output_type_id: string"
   )
   expect_equal(

--- a/tests/testthat/test-hub-connection.R
+++ b/tests/testthat/test-hub-connection.R
@@ -390,3 +390,22 @@ test_that("connect_hub detects unopenned files correctly", {
   hub_path <- testthat::test_path("testdata/error_file")
   expect_snapshot(connect_hub(hub_path))
 })
+
+test_that("output_type_id_datatype arg works in connect_hub on local hub", {
+  # Simple forecasting Hub example ----
+  hub_path <- system.file("testhubs/simple", package = "hubUtils")
+
+  # Test default reverts to "auto"
+  expect_equal(
+    connect_hub(hub_path
+    )$schema$GetFieldByName("output_type_id")$ToString(),
+    "output_type_id: double"
+  )
+  # Test that override works
+  expect_equal(
+    connect_hub(
+      hub_path, output_type_id_datatype = "character"
+      )$schema$GetFieldByName("output_type_id")$ToString(),
+    "output_type_id: string"
+  )
+})

--- a/tests/testthat/test-hub-connection.R
+++ b/tests/testthat/test-hub-connection.R
@@ -397,15 +397,15 @@ test_that("output_type_id_datatype arg works in connect_hub on local hub", {
 
   # Test default reverts to "auto"
   expect_equal(
-    connect_hub(hub_path
-    )$schema$GetFieldByName("output_type_id")$ToString(),
+    connect_hub(hub_path)$schema$GetFieldByName("output_type_id")$ToString(),
     "output_type_id: double"
   )
   # Test that override works
   expect_equal(
     connect_hub(
-      hub_path, output_type_id_datatype = "character"
-      )$schema$GetFieldByName("output_type_id")$ToString(),
+      hub_path,
+      output_type_id_datatype = "character"
+    )$schema$GetFieldByName("output_type_id")$ToString(),
     "output_type_id: string"
   )
 })

--- a/tests/testthat/testdata/configs/tasks-set-otid-datatype.json
+++ b/tests/testthat/testdata/configs/tasks-set-otid-datatype.json
@@ -1,0 +1,259 @@
+{
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json",
+    "rounds": [
+        {
+            "round_id_from_variable": true,
+            "round_id": "origin_date",
+            "model_tasks": [
+                {
+                    "task_ids": {
+                        "origin_date": {
+                            "required": null,
+                            "optional": [
+                                "2023-10-07", "2023-10-14", "2023-10-21", "2023-10-28", "2023-11-04",
+                                "2023-11-11", "2023-11-18", "2023-11-25", "2023-12-02",
+                                "2023-12-09", "2023-12-16", "2023-12-23", "2023-12-30",
+                                "2024-01-06", "2024-01-13", "2024-01-20", "2024-01-27",
+                                "2024-02-03", "2024-02-10", "2024-02-17", "2024-02-24",
+                                "2024-03-02", "2024-03-09", "2024-03-16", "2024-03-23",
+                                "2024-03-30", "2024-04-06", "2024-04-13", "2024-04-20",
+                                "2024-04-27", "2024-05-04", "2024-05-11"
+                            ]
+                        },
+                        "target": {
+                            "required": ["ILI incidence"],
+                            "optional": null
+                        },
+                        "target_end_date": {
+                            "required": null,
+                            "optional": [
+                                "2023-09-23", "2023-09-30", "2023-10-07",
+                                "2023-10-14", "2023-10-21", "2023-10-28", "2023-11-04",
+                                "2023-11-11", "2023-11-18", "2023-11-25", "2023-12-02",
+                                "2023-12-09", "2023-12-16", "2023-12-23", "2023-12-30",
+                                "2024-01-06", "2024-01-13", "2024-01-20", "2024-01-27",
+                                "2024-02-03", "2024-02-10", "2024-02-17", "2024-02-24",
+                                "2024-03-02", "2024-03-09", "2024-03-16", "2024-03-23",
+                                "2024-03-30", "2024-04-06", "2024-04-13", "2024-04-20",
+                                "2024-04-27", "2024-05-04", "2024-05-11", "2024-05-18",
+                                "2024-05-25", "2024-06-01"
+                            ]
+                        },
+                        "horizon": {
+                            "required": null,
+                            "optional": [1, 2, 3, 4]
+                        },
+                        "location": {
+                            "required": null,
+                            "optional": [
+                                "AT",
+                                "BE",
+                                "BG",
+                                "CH",
+                                "CY",
+                                "CZ",
+                                "DE",
+                                "DK",
+                                "EE",
+                                "ES",
+                                "FI",
+                                "FR",
+                                "UK",
+                                "GR",
+                                "HR",
+                                "HU",
+                                "IE",
+                                "IS",
+                                "IT",
+                                "LI",
+                                "LT",
+                                "LU",
+                                "LV",
+                                "MT",
+                                "NL",
+                                "NO",
+                                "PL",
+                                "PT",
+                                "RO",
+                                "SE",
+                                "SI",
+                                "SK"
+                            ]
+                        }
+                    },
+                    "output_type": {
+                        "quantile": {
+                            "output_type_id": {
+                                "required": [
+                                    0.010,
+                                    0.025,
+                                    0.050,
+                                    0.100,
+                                    0.150,
+                                    0.200,
+                                    0.250,
+                                    0.300,
+                                    0.350,
+                                    0.400,
+                                    0.450,
+                                    0.500,
+                                    0.550,
+                                    0.600,
+                                    0.650,
+                                    0.700,
+                                    0.750,
+                                    0.800,
+                                    0.850,
+                                    0.900,
+                                    0.950,
+                                    0.975,
+                                    0.990
+                                ],
+                                "optional": null
+                            },
+                            "value": {
+                                "type": "double",
+                                "minimum": 0
+                            }
+                        },
+                        "sample": {
+                            "output_type_id_params": {
+                                "is_required": false,
+                                "type": "integer",
+                                "min_samples_per_task": 1,
+                                "max_samples_per_task": 1
+                            },
+                            "value": {
+                                "type": "integer",
+                                "minimum": 0
+                            }
+                        }
+                    },
+                    "target_metadata": [
+                        {
+                           "target_id": "ILI incidence",
+                           "target_name": "Weekly incidence for Influenza like illness",
+                           "target_units": "cases per 100,000 population",
+                           "target_keys": {
+                               "target": "ILI incidence"
+                           },
+                           "description": "This target represents the count of new ILI cases per 100,000 in the week ending on the date [horizon] weeks after the reference_date",
+                           "target_type": "continuous",
+                           "is_step_ahead": true,
+                           "time_unit": "week"
+                        }
+                    ]
+                },
+                {
+                    "task_ids": {
+                        "origin_date": {
+                            "required": null,
+                            "optional": [
+                                "2023-10-07", "2023-10-14", "2023-10-21", "2023-10-28", "2023-11-04",
+                                "2023-11-11", "2023-11-18", "2023-11-25", "2023-12-02",
+                                "2023-12-09", "2023-12-16", "2023-12-23", "2023-12-30",
+                                "2024-01-06", "2024-01-13", "2024-01-20", "2024-01-27",
+                                "2024-02-03", "2024-02-10", "2024-02-17", "2024-02-24",
+                                "2024-03-02", "2024-03-09", "2024-03-16", "2024-03-23",
+                                "2024-03-30", "2024-04-06", "2024-04-13", "2024-04-20",
+                                "2024-04-27", "2024-05-04", "2024-05-11"
+                            ]
+                        },
+                        "target": {
+                            "required": ["ILI incidence median"],
+                            "optional": null
+                        },
+                        "target_end_date": {
+                            "required": null,
+                            "optional": [
+                                "2023-09-23", "2023-09-30", "2023-10-07",
+                                "2023-10-14", "2023-10-21", "2023-10-28", "2023-11-04",
+                                "2023-11-11", "2023-11-18", "2023-11-25", "2023-12-02",
+                                "2023-12-09", "2023-12-16", "2023-12-23", "2023-12-30",
+                                "2024-01-06", "2024-01-13", "2024-01-20", "2024-01-27",
+                                "2024-02-03", "2024-02-10", "2024-02-17", "2024-02-24",
+                                "2024-03-02", "2024-03-09", "2024-03-16", "2024-03-23",
+                                "2024-03-30", "2024-04-06", "2024-04-13", "2024-04-20",
+                                "2024-04-27", "2024-05-04", "2024-05-11", "2024-05-18",
+                                "2024-05-25", "2024-06-01"
+                            ]
+                        },
+                        "horizon": {
+                            "required": null,
+                            "optional": [1, 2, 3, 4]
+                        },
+                        "location": {
+                            "required": null,
+                            "optional": [
+                                "AT",
+                                "BE",
+                                "BG",
+                                "CH",
+                                "CY",
+                                "CZ",
+                                "DE",
+                                "DK",
+                                "EE",
+                                "ES",
+                                "FI",
+                                "FR",
+                                "UK",
+                                "GR",
+                                "HR",
+                                "HU",
+                                "IE",
+                                "IS",
+                                "IT",
+                                "LI",
+                                "LT",
+                                "LU",
+                                "LV",
+                                "MT",
+                                "NL",
+                                "NO",
+                                "PL",
+                                "PT",
+                                "RO",
+                                "SE",
+                                "SI",
+                                "SK"
+                            ]
+                        }
+                    },
+                    "output_type": {
+                        "median": {
+                            "output_type_id": {
+                                "required": null,
+                                "optional": ["NA"]
+                            },
+                            "value": {
+                                "type": "double",
+                                "minimum": 0
+                            }
+                        }
+                    },
+                    "target_metadata": [
+                        {
+                           "target_id": "ILI incidence median",
+                           "target_name": "Weekly incidence for Influenza like illness",
+                           "target_units": "cases per 100,000 population",
+                           "target_keys": {
+                               "target": "ILI incidence median"
+                           },
+                           "description": "This target represents the count of new ILI cases per 100,000 in the week ending on the date [horizon] weeks after the reference_date",
+                           "target_type": "continuous",
+                           "is_step_ahead": true,
+                           "time_unit": "week"
+                        }
+                    ]
+                }
+            ],
+            "submissions_due": {
+                "relative_to": "origin_date",
+                "start": -6,
+                "end": 0
+            }
+        }
+    ],
+    "output_type_id_datatype": "character"
+}


### PR DESCRIPTION
This PR adds a `"from_config"` option to the `output_type_id_datatype` argument in `create_hub_schema()`, `coerce_to_hub_schema()` and `connect_hub()`. This allows users to set the hub level `output_type_id` column data type through the `tasks.json` `output_type_id_datatype` property introduced in schema version v3.0.1. (Resolves #44)

If the `output_type_id_datatype` property is not provided or set to 'auto' in `tasks.json`, functions fall back to autodetecting the simplest hub level data type (the default up to now).

For more details, see PR in schema:  https://github.com/hubverse-org/schemas/pull/88
And related issues in other repos: https://github.com/orgs/hubverse-org/projects/3/views/12
