### PR TITLE
fix tidyselect warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubData
 Title: Tools for accessing and working with hubverse data
-Version: 1.1.0
+Version: 1.1.1
 Authors@R: 
     c(person("Anna", "Krystalli", , "annakrystalli@googlemail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2378-4915")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     arrow (>= 12.0.0),
     checkmate,
     cli,
-    dplyr,
+    dplyr (>= 1.1.0),
     fs,
     hubUtils (>= 0.1.0),
     lifecycle,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# hubData 1.1.1
+
+* Fix {tidyselect} warnings by converting internal syntax
+* Bump required dplyr version to 1.1.0
+
 # hubData 1.1.0
 
 * Add `"from_config"` option to the `output_type_id_datatype` argument in `create_hub_schema()`, `coerce_to_hub_schema()` and `connect_hub()`. This allows users to set the hub level `output_type_id` column data type through the `tasks.json` `output_type_id_datatype` property introduced in schema version v3.0.1. (#44)

--- a/R/collect_zoltar.R
+++ b/R/collect_zoltar.R
@@ -122,7 +122,7 @@ format_to_hub_model_output <- function(forecasts, zoltar_targets_df, point_outpu
         split_outputs |>
           dplyr::mutate(output_type = "sample", hub_value = suppressWarnings(as.numeric(sample))) |>
           dplyr::group_by(.data$model, .data$timezero, .data$unit, .data$target) |>
-          dplyr::mutate(output_type_id = as.character(dplyr::row_number()), .before = .data$hub_value) |>
+          dplyr::mutate(output_type_id = as.character(dplyr::row_number()), .before = "hub_value") |>
           dplyr::ungroup()
       }
     }) |>
@@ -136,8 +136,8 @@ format_to_hub_model_output <- function(forecasts, zoltar_targets_df, point_outpu
 
   hub_model_outputs[, c("model", "timezero", "season", "unit", "numeric_horizon", "hub_target", "output_type",
                         "output_type_id", "hub_value")] |>
-    dplyr::rename(model_id = .data$model, horizon = .data$numeric_horizon, target = .data$hub_target,
-                  value = .data$hub_value)
+    dplyr::rename(model_id = "model", horizon = "numeric_horizon", target = "hub_target",
+                  value = "hub_value")
 }
 
 validate_arguments <- function(zoltar_connection, project_name, models, timezeros, units, targets, types, as_of,


### PR DESCRIPTION
This PR does the following:

1. bumps the version of dplyr to 1.1.0 so that we can guarantee tidyselect 1.2.0
   without having to add it to our dependencies (even though it's implicit).
2. fixes the tidyselect syntax for the select statements. 

## Background

I was running tests for this package when I saw a flood of warnings that all looked like the one at the bottom of this issue.

I then saw https://github.com/hubverse-org/hubData/pull/36#discussion_r1637826949 and experimented a bit with the fix. 

As I understand it, the `.data$` syntax is no longer valid for `select` operations, which includes the `.before` statement in mutate operations and `rename` (IIRC `rename` was formalising the secret menu of `select` where you could change the column names on the fly). 

TBH, I changed every `.data$` command and then got errors and then actually read Anna's comment again.


## The Warning

```r
Warning (test-collect_zoltar.R:73:3): format_to_hub_model_output() expected output, default point_output_type
Use of .data in tidyselect expressions was deprecated in tidyselect 1.2.0.
i Please use `"hub_value"` instead of `.data$hub_value`
Backtrace:
     ▆
  1. ├─testthat::expect_warning(...) at test-collect_zoltar.R:73:3
  2. │ └─testthat:::expect_condition_matching(...)
  3. │   └─testthat:::quasi_capture(...)
  4. │     ├─testthat (local) .capture(...)
  5. │     │ └─base::withCallingHandlers(...)
  6. │     └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
  7. ├─dplyr::arrange(...)
  8. └─hubData:::format_to_hub_model_output(...)
  9.   ├─dplyr::filter(...) at hubData/R/collect_zoltar.R:92:3
 10.   ├─purrr::list_rbind(...)
 11.   │ └─purrr:::check_list_of_data_frames(x)
 12.   │   └─vctrs::vec_check_list(x, call = error_call)
 13.   │     └─vctrs::obj_check_list(x, ..., arg = arg, call = call)
 14.   └─purrr::map(...)
 15.     └─purrr:::map_("list", .x, .f, ..., .progress = .progress)
 16.       ├─purrr:::with_indexed_errors(...)
 17.       │ └─base::withCallingHandlers(...)
 18.       ├─purrr:::call_with_cleanup(...)
 19.       └─hubData (local) .f(.x[[i]], ...)
 20.         ├─dplyr::ungroup(...) at hubData/R/collect_zoltar.R:122:9
 21.         ├─dplyr::mutate(...)
 22.         └─dplyr:::mutate.data.frame(...)
 23.           └─dplyr:::mutate_relocate(...)
 24.             ├─dplyr::relocate(out, all_of(names), .before = !!before, .after = !!after)
 25.             └─dplyr:::relocate.data.frame(...)
 26.               └─dplyr:::eval_relocate(...)
 27.                 └─tidyselect::eval_select(before, data, env = env, error_call = error_call)
 28.                   └─tidyselect:::eval_select_impl(...)
 29.                     ├─tidyselect:::with_subscript_errors(...)
 30.                     │ └─base::withCallingHandlers(...)
 31.                     └─tidyselect:::vars_select_eval(...)
 32.                       └─tidyselect:::walk_data_tree(expr, data_mask, context_mask)
 33.                         └─tidyselect:::expr_kind(expr, context_mask, error_call)
 34.                           └─tidyselect:::call_kind(expr, context_mask, error_call)
```
