### PR TITLE
Hotfix / Use CRAN arrow

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubData
 Title: Tools for accessing and working with hubverse data
-Version: 1.2.1
+Version: 1.2.2
 Authors@R: 
     c(person("Anna", "Krystalli", , "annakrystalli@googlemail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2378-4915")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Config/testthat/edition: 3
 URL: https://github.com/hubverse-org/hubData
 BugReports: https://github.com/hubverse-org/hubData/issues
 Imports: 
-    arrow (>= 12.0.0),
+    arrow (>= 17.0.0),
     checkmate,
     cli,
     dplyr (>= 1.1.0),
@@ -47,8 +47,7 @@ Suggests:
     rmarkdown,
     testthat (>= 3.2.0)
 Remotes:
-    hubverse-org/hubUtils,
-    apache/arrow/r@apache-arrow-15.0.2
+    hubverse-org/hubUtils
 Config/Needs/website: hubverse-org/hubStyle
 Depends: 
     R (>= 2.10)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# hubData 1.2.2
+
+* Remove dependency on development version of `arrow` package and bump required version to 17.0.0.
+
+
 # hubData 1.2.1
 
 * Removed dependency on development version of `zoltr` package.

--- a/man/as_model_out_tbl.Rd
+++ b/man/as_model_out_tbl.Rd
@@ -10,12 +10,14 @@ A \code{model_out_tbl} class object.
 See \code{\link[hubUtils:as_model_out_tbl]{hubUtils::as_model_out_tbl()}} for details.
 }
 \examples{
-library(dplyr)
-hub_path <- system.file("testhubs/flusight", package = "hubUtils")
-hub_con <- hubData::connect_hub(hub_path)
-hub_con \%>\%
-  filter(output_type == "quantile", location == "US") \%>\%
-  collect() \%>\%
-  filter(forecast_date == max(forecast_date)) \%>\%
-  as_model_out_tbl()
+if (requireNamespace("hubData", quietly = TRUE)) {
+  library(dplyr)
+  hub_path <- system.file("testhubs/flusight", package = "hubUtils")
+  hub_con <- hubData::connect_hub(hub_path)
+  hub_con \%>\%
+    filter(output_type == "quantile", location == "US") \%>\%
+    collect() \%>\%
+    filter(forecast_date == max(forecast_date)) \%>\%
+    as_model_out_tbl()
+}
 }

--- a/man/model_id_merge.Rd
+++ b/man/model_id_merge.Rd
@@ -6,29 +6,34 @@
 \value{
 \code{tbl} with either \code{team_abbr} and \code{model_abbr} merged into a single \code{model_id}
 column or \code{model_id} split into columns \code{team_abbr} and \code{model_abbr}.
+
+a \link[tibble:tibble]{tibble} with \code{model_id} column split into separate
+\code{team_abbr} and \code{model_abbr} columns
 }
 \description{
 See \code{\link[hubUtils:model_id_merge]{hubUtils::model_id_merge()}} for details.
 }
 \examples{
-hub_con <- hubData::connect_hub(system.file("testhubs/flusight", package = "hubUtils"))
-tbl <- hub_con \%>\%
-  dplyr::filter(output_type == "quantile", location == "US") \%>\%
-  dplyr::collect() \%>\%
-  dplyr::filter(forecast_date == max(forecast_date))
+if (requireNamespace("hubData", quietly = TRUE)) {
+  hub_con <- hubData::connect_hub(system.file("testhubs/flusight", package = "hubUtils"))
+  tbl <- hub_con \%>\%
+    dplyr::filter(output_type == "quantile", location == "US") \%>\%
+    dplyr::collect() \%>\%
+    dplyr::filter(forecast_date == max(forecast_date))
 
-tbl_split <- model_id_split(tbl)
-tbl_split
+  tbl_split <- model_id_split(tbl)
+  tbl_split
 
-# Merge model_id
-tbl_merged <- model_id_merge(tbl_split)
-tbl_merged
+  # Merge model_id
+  tbl_merged <- model_id_merge(tbl_split)
+  tbl_merged
 
-# Split / Merge using custom separator
-tbl_sep <- tbl
-tbl_sep$model_id <- gsub("-", "_", tbl_sep$model_id)
-tbl_sep <- model_id_split(tbl_sep, sep = "_")
-tbl_sep
-tbl_sep <- model_id_merge(tbl_sep, sep = "_")
-tbl_sep
+  # Split / Merge using custom separator
+  tbl_sep <- tbl
+  tbl_sep$model_id <- gsub("-", "_", tbl_sep$model_id)
+  tbl_sep <- model_id_split(tbl_sep, sep = "_")
+  tbl_sep
+  tbl_sep <- model_id_merge(tbl_sep, sep = "_")
+  tbl_sep
+}
 }

--- a/man/model_id_split.Rd
+++ b/man/model_id_split.Rd
@@ -6,29 +6,34 @@
 \value{
 \code{tbl} with either \code{team_abbr} and \code{model_abbr} merged into a single \code{model_id}
 column or \code{model_id} split into columns \code{team_abbr} and \code{model_abbr}.
+
+a \link[tibble:tibble]{tibble} with \code{model_id} column split into separate
+\code{team_abbr} and \code{model_abbr} columns
 }
 \description{
 See \code{\link[hubUtils:model_id_merge]{hubUtils::model_id_merge()}} for details.
 }
 \examples{
-hub_con <- hubData::connect_hub(system.file("testhubs/flusight", package = "hubUtils"))
-tbl <- hub_con \%>\%
-  dplyr::filter(output_type == "quantile", location == "US") \%>\%
-  dplyr::collect() \%>\%
-  dplyr::filter(forecast_date == max(forecast_date))
+if (requireNamespace("hubData", quietly = TRUE)) {
+  hub_con <- hubData::connect_hub(system.file("testhubs/flusight", package = "hubUtils"))
+  tbl <- hub_con \%>\%
+    dplyr::filter(output_type == "quantile", location == "US") \%>\%
+    dplyr::collect() \%>\%
+    dplyr::filter(forecast_date == max(forecast_date))
 
-tbl_split <- model_id_split(tbl)
-tbl_split
+  tbl_split <- model_id_split(tbl)
+  tbl_split
 
-# Merge model_id
-tbl_merged <- model_id_merge(tbl_split)
-tbl_merged
+  # Merge model_id
+  tbl_merged <- model_id_merge(tbl_split)
+  tbl_merged
 
-# Split / Merge using custom separator
-tbl_sep <- tbl
-tbl_sep$model_id <- gsub("-", "_", tbl_sep$model_id)
-tbl_sep <- model_id_split(tbl_sep, sep = "_")
-tbl_sep
-tbl_sep <- model_id_merge(tbl_sep, sep = "_")
-tbl_sep
+  # Split / Merge using custom separator
+  tbl_sep <- tbl
+  tbl_sep$model_id <- gsub("-", "_", tbl_sep$model_id)
+  tbl_sep <- model_id_split(tbl_sep, sep = "_")
+  tbl_sep
+  tbl_sep <- model_id_merge(tbl_sep, sep = "_")
+  tbl_sep
+}
 }

--- a/man/s3_bucket.Rd
+++ b/man/s3_bucket.Rd
@@ -18,7 +18,7 @@ bucket <- s3_bucket("voltrondata-labs-datasets")
 \dontshow{if (FALSE) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # Turn on debug logging. The following line of code should be run in a fresh
 # R session prior to any calls to `s3_bucket()` (or other S3 functions)
-Sys.setenv("ARROW_S3_LOG_LEVEL", "DEBUG")
+Sys.setenv("ARROW_S3_LOG_LEVEL"="DEBUG")
 bucket <- s3_bucket("voltrondata-labs-datasets")
 \dontshow{\}) # examplesIf}
 }

--- a/man/validate_model_out_tbl.Rd
+++ b/man/validate_model_out_tbl.Rd
@@ -4,20 +4,23 @@
 \alias{validate_model_out_tbl}
 \title{Validate a \code{model_out_tbl} object}
 \value{
-If valid, returns a \code{tbl}. Otherwise throws an error.
+If valid, returns a \code{model_out_tbl} class object. Otherwise, throws an
+error.
 }
 \description{
 See \code{\link[hubUtils:validate_model_out_tbl]{hubUtils::validate_model_out_tbl()}} for details.
 }
 \examples{
-library(dplyr)
-hub_path <- system.file("testhubs/flusight", package = "hubUtils")
-hub_con <- hubData::connect_hub(hub_path)
-md_out <- hub_con \%>\%
-  filter(output_type == "quantile", location == "US") \%>\%
-  collect() \%>\%
-  filter(forecast_date == max(forecast_date)) \%>\%
-  as_model_out_tbl()
+if (requireNamespace("hubData", quietly = TRUE)) {
+  library(dplyr)
+  hub_path <- system.file("testhubs/flusight", package = "hubUtils")
+  hub_con <- hubData::connect_hub(hub_path)
+  md_out <- hub_con \%>\%
+    filter(output_type == "quantile", location == "US") \%>\%
+    collect() \%>\%
+    filter(forecast_date == max(forecast_date)) \%>\%
+    as_model_out_tbl()
 
-validate_model_out_tbl(md_out)
+  validate_model_out_tbl(md_out)
+}
 }

--- a/tests/testthat/_snaps/hub-connection.md
+++ b/tests/testthat/_snaps/hub-connection.md
@@ -644,6 +644,7 @@
       -- Connection schema 
     Output
       mod_out_connection with 3 csv files
+      8 columns
       origin_date: date32[day]
       target: string
       horizon: int64
@@ -705,6 +706,7 @@
       -- Connection schema 
     Output
       mod_out_connection with 3 csv files
+      8 columns
       origin_date: date32[day]
       target: string
       horizon: int32
@@ -766,6 +768,7 @@
       -- Connection schema 
     Output
       hub_connection
+      9 columns
       origin_date: date32[day]
       target: string
       horizon: int32
@@ -796,6 +799,7 @@
       -- Connection schema 
     Output
       hub_connection
+      9 columns
       origin_date: date32[day]
       target: string
       horizon: int32
@@ -966,6 +970,7 @@
       -- Connection schema 
     Output
       mod_out_connection with 3 csv files
+      8 columns
       origin_date: date32[day]
       target: string
       horizon: int64
@@ -1382,6 +1387,7 @@
       -- Connection schema 
     Output
       hub_connection with 4 Parquet files
+      9 columns
       origin_date: date32[day]
       target: string
       horizon: int32
@@ -1586,6 +1592,22 @@
       Error in `connect_hub()`:
       x 'hub-config' directory not found in root of Hub.
 
+# connect_hub fails when skip_checks is true and hub has multiple file types
+
+    Code
+      connect_hub(hub_path, skip_checks = TRUE)
+    Condition
+      Error in `connect_hub()`:
+      ! Skip_checks cannot be TRUE when there are multiple file formats in the model output directory ("csv" and "parquet").
+
+# connect_model_output fails when skip_checks is true and hub has multiple file types
+
+    Code
+      connect_model_output(mod_out_path, skip_checks = TRUE)
+    Condition
+      Error in `connect_model_output()`:
+      ! Skip_checks cannot be TRUE when there are multiple file formats in the model output directory ("csv" and "parquet").
+
 # connect_hub detects unopenned files correctly
 
     Code
@@ -1610,6 +1632,7 @@
       -- Connection schema 
     Output
       hub_connection with 8 csv files
+      8 columns
       origin_date: date32[day]
       horizon: int32
       location: string
@@ -1639,6 +1662,7 @@
       -- Connection schema 
     Output
       hub_connection with 9 csv files
+      8 columns
       origin_date: date32[day]
       horizon: int32
       location: string


### PR DESCRIPTION
This PR removes the `arrow` development version requirement and bumps the minimum required to CRAN version 17.0.0.

Snapshots are also updated with some minor changes introduced in new arrow version (arrow schema now print the number of columns) and a couple of missing snapshots from #47 

It also updates documentation of re-exported functions with upstream changes.