### PR TITLE
bump to dev; fix tests for hubUtils 0.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,8 @@ Suggests:
     knitr,
     mockery,
     rmarkdown,
-    testthat (>= 3.2.0)
+    testthat (>= 3.2.0),
+    withr
 Remotes:
     hubverse-org/hubUtils
 Config/Needs/website: hubverse-org/hubStyle

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubData
 Title: Tools for accessing and working with hubverse data
-Version: 1.2.3
+Version: 1.2.3.9000
 Authors@R: 
     c(person("Anna", "Krystalli", , "annakrystalli@googlemail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2378-4915")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# hubData (development version)
+
 # hubData 1.2.3
 
 * Fix bug in `create_hub_schema()` where `output_type_id` data type was being incorrectly determined as `Date` instead of `character` (Reported in https://github.com/reichlab/variant-nowcast-hub/pull/87#issuecomment-2387372238).

--- a/tests/testthat/_snaps/hub-connection.md
+++ b/tests/testthat/_snaps/hub-connection.md
@@ -47,6 +47,9 @@
         .. .. ..$ model_type: chr "baseline"
         ..$ file_format   : chr [1:3] "csv" "parquet" "arrow"
         ..$ timezone      : chr "US/Eastern"
+        ..- attr(*, "schema_id")= chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/admin-schema.json"
+        ..- attr(*, "type")= chr "admin"
+        ..- attr(*, "class")= chr [1:2] "config" "list"
        - attr(*, "config_tasks")=List of 2
         ..$ schema_version: chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
         ..$ rounds        :List of 2
@@ -147,6 +150,9 @@
         .. .. .. ..$ relative_to: chr "origin_date"
         .. .. .. ..$ start      : int -6
         .. .. .. ..$ end        : int 1
+        ..- attr(*, "schema_id")= chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
+        ..- attr(*, "type")= chr "tasks"
+        ..- attr(*, "class")= chr [1:2] "config" "list"
 
 # connect_hub works on a local simple forecasting hub with no csvs
 
@@ -200,6 +206,9 @@
         .. .. ..$ model_type: chr "baseline"
         ..$ file_format   : chr [1:3] "csv" "parquet" "arrow"
         ..$ timezone      : chr "US/Eastern"
+        ..- attr(*, "schema_id")= chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/admin-schema.json"
+        ..- attr(*, "type")= chr "admin"
+        ..- attr(*, "class")= chr [1:2] "config" "list"
        - attr(*, "config_tasks")=List of 2
         ..$ schema_version: chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
         ..$ rounds        :List of 2
@@ -300,6 +309,9 @@
         .. .. .. ..$ relative_to: chr "origin_date"
         .. .. .. ..$ start      : int -6
         .. .. .. ..$ end        : int 1
+        ..- attr(*, "schema_id")= chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
+        ..- attr(*, "type")= chr "tasks"
+        ..- attr(*, "class")= chr [1:2] "config" "list"
 
 # connect_hub returns empty list when model output folder is empty
 
@@ -395,6 +407,9 @@
         ..$ file_format     : chr [1:3] "csv" "parquet" "arrow"
         ..$ timezone        : chr "US/Eastern"
         ..$ model_output_dir: chr "forecasts"
+        ..- attr(*, "schema_id")= chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/admin-schema.json"
+        ..- attr(*, "type")= chr "admin"
+        ..- attr(*, "class")= chr [1:2] "config" "list"
        - attr(*, "config_tasks")=List of 2
         ..$ schema_version: chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
         ..$ rounds        :List of 1
@@ -480,6 +495,9 @@
         .. .. .. ..$ relative_to: chr "forecast_date"
         .. .. .. ..$ start      : int -6
         .. .. .. ..$ end        : int 2
+        ..- attr(*, "schema_id")= chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
+        ..- attr(*, "type")= chr "tasks"
+        ..- attr(*, "class")= chr [1:2] "config" "list"
 
 ---
 
@@ -542,6 +560,9 @@
         ..$ file_format     : chr [1:3] "csv" "parquet" "arrow"
         ..$ timezone        : chr "US/Eastern"
         ..$ model_output_dir: chr "forecasts"
+        ..- attr(*, "schema_id")= chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/admin-schema.json"
+        ..- attr(*, "type")= chr "admin"
+        ..- attr(*, "class")= chr [1:2] "config" "list"
        - attr(*, "config_tasks")=List of 2
         ..$ schema_version: chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
         ..$ rounds        :List of 1
@@ -627,6 +648,9 @@
         .. .. .. ..$ relative_to: chr "forecast_date"
         .. .. .. ..$ start      : int -6
         .. .. .. ..$ end        : int 2
+        ..- attr(*, "schema_id")= chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
+        ..- attr(*, "type")= chr "tasks"
+        ..- attr(*, "class")= chr [1:2] "config" "list"
 
 # connect_model_output works on local model_output_dir
 
@@ -853,6 +877,9 @@
         .. .. ..$ model_type: chr "baseline"
         ..$ file_format   : chr [1:3] "csv" "parquet" "arrow"
         ..$ timezone      : chr "US/Eastern"
+        ..- attr(*, "schema_id")= chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/admin-schema.json"
+        ..- attr(*, "type")= chr "admin"
+        ..- attr(*, "class")= chr [1:2] "config" "list"
        - attr(*, "config_tasks")=List of 2
         ..$ schema_version: chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
         ..$ rounds        :List of 2
@@ -953,6 +980,9 @@
         .. .. .. ..$ relative_to: chr "origin_date"
         .. .. .. ..$ start      : int -6
         .. .. .. ..$ end        : int 1
+        ..- attr(*, "schema_id")= chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
+        ..- attr(*, "type")= chr "tasks"
+        ..- attr(*, "class")= chr [1:2] "config" "list"
 
 # mod_out_connection print method works
 
@@ -1065,7 +1095,7 @@
        - attr(*, "hub_path")= chr "test/hub_path"
        - attr(*, "model_output_dir")= chr "test/model_output_dir"
        - attr(*, "config_admin")=List of 8
-        ..$ schema_version: chr "https://raw.githubusercontent.com/Infectious-Disease-Modeling-Hubs/schemas/main/v2.0.0/admin-schema.json"
+        ..$ schema_version: chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/admin-schema.json"
         ..$ name          : chr "Simple Forecast Hub"
         ..$ maintainer    : chr "Consortium of Infectious Disease Modeling Hubs"
         ..$ contact       :List of 2
@@ -1079,8 +1109,11 @@
         .. .. ..$ model_type: chr "baseline"
         ..$ file_format   : chr [1:3] "csv" "parquet" "arrow"
         ..$ timezone      : chr "US/Eastern"
+        ..- attr(*, "schema_id")= chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/admin-schema.json"
+        ..- attr(*, "type")= chr "admin"
+        ..- attr(*, "class")= chr [1:2] "config" "list"
        - attr(*, "config_tasks")=List of 2
-        ..$ schema_version: chr "https://raw.githubusercontent.com/Infectious-Disease-Modeling-Hubs/schemas/main/v2.0.0/tasks-schema.json"
+        ..$ schema_version: chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
         ..$ rounds        :List of 2
         .. ..$ :List of 4
         .. .. ..$ round_id_from_variable: logi TRUE
@@ -1179,6 +1212,9 @@
         .. .. .. ..$ relative_to: chr "origin_date"
         .. .. .. ..$ start      : int -6
         .. .. .. ..$ end        : int 1
+        ..- attr(*, "schema_id")= chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
+        ..- attr(*, "type")= chr "tasks"
+        ..- attr(*, "class")= chr [1:2] "config" "list"
 
 ---
 
@@ -1235,7 +1271,7 @@
        - attr(*, "hub_path")= chr "test/hub_path"
        - attr(*, "model_output_dir")= chr "test/model_output_dir"
        - attr(*, "config_admin")=List of 8
-        ..$ schema_version: chr "https://raw.githubusercontent.com/Infectious-Disease-Modeling-Hubs/schemas/main/v2.0.0/admin-schema.json"
+        ..$ schema_version: chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/admin-schema.json"
         ..$ name          : chr "Simple Forecast Hub"
         ..$ maintainer    : chr "Consortium of Infectious Disease Modeling Hubs"
         ..$ contact       :List of 2
@@ -1249,8 +1285,11 @@
         .. .. ..$ model_type: chr "baseline"
         ..$ file_format   : chr [1:3] "csv" "parquet" "arrow"
         ..$ timezone      : chr "US/Eastern"
+        ..- attr(*, "schema_id")= chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/admin-schema.json"
+        ..- attr(*, "type")= chr "admin"
+        ..- attr(*, "class")= chr [1:2] "config" "list"
        - attr(*, "config_tasks")=List of 2
-        ..$ schema_version: chr "https://raw.githubusercontent.com/Infectious-Disease-Modeling-Hubs/schemas/main/v2.0.0/tasks-schema.json"
+        ..$ schema_version: chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
         ..$ rounds        :List of 2
         .. ..$ :List of 4
         .. .. ..$ round_id_from_variable: logi TRUE
@@ -1349,6 +1388,9 @@
         .. .. .. ..$ relative_to: chr "origin_date"
         .. .. .. ..$ start      : int -6
         .. .. .. ..$ end        : int 1
+        ..- attr(*, "schema_id")= chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
+        ..- attr(*, "type")= chr "tasks"
+        ..- attr(*, "class")= chr [1:2] "config" "list"
 
 ---
 
@@ -1436,7 +1478,7 @@
        - attr(*, "hub_path")= chr "test/hub_path"
        - attr(*, "model_output_dir")= chr "test/model_output_dir"
        - attr(*, "config_admin")=List of 8
-        ..$ schema_version: chr "https://raw.githubusercontent.com/Infectious-Disease-Modeling-Hubs/schemas/main/v2.0.0/admin-schema.json"
+        ..$ schema_version: chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/admin-schema.json"
         ..$ name          : chr "Simple Forecast Hub"
         ..$ maintainer    : chr "Consortium of Infectious Disease Modeling Hubs"
         ..$ contact       :List of 2
@@ -1450,8 +1492,11 @@
         .. .. ..$ model_type: chr "baseline"
         ..$ file_format   : chr [1:3] "csv" "parquet" "arrow"
         ..$ timezone      : chr "US/Eastern"
+        ..- attr(*, "schema_id")= chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/admin-schema.json"
+        ..- attr(*, "type")= chr "admin"
+        ..- attr(*, "class")= chr [1:2] "config" "list"
        - attr(*, "config_tasks")=List of 2
-        ..$ schema_version: chr "https://raw.githubusercontent.com/Infectious-Disease-Modeling-Hubs/schemas/main/v2.0.0/tasks-schema.json"
+        ..$ schema_version: chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
         ..$ rounds        :List of 2
         .. ..$ :List of 4
         .. .. ..$ round_id_from_variable: logi TRUE
@@ -1550,6 +1595,9 @@
         .. .. .. ..$ relative_to: chr "origin_date"
         .. .. .. ..$ start      : int -6
         .. .. .. ..$ end        : int 1
+        ..- attr(*, "schema_id")= chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
+        ..- attr(*, "type")= chr "tasks"
+        ..- attr(*, "class")= chr [1:2] "config" "list"
 
 ---
 

--- a/tests/testthat/test-hub-connection.R
+++ b/tests/testthat/test-hub-connection.R
@@ -320,7 +320,6 @@ test_that("connect_hub data extraction works on simple forecasting hub", {
   hub_path <- system.file("testhubs/simple", package = "hubUtils")
   hub_con <- connect_hub(hub_path)
 
-  suppressMessages(library(dplyr))
   expect_snapshot(hub_con %>%
     dplyr::filter(
       origin_date == "2022-10-08",

--- a/tests/testthat/test-hub-connection.R
+++ b/tests/testthat/test-hub-connection.R
@@ -93,7 +93,7 @@ test_that("connect_hub returns empty list when model output folder is empty", {
   hub_path <- s3_bucket("hubverse/hubutils/testhubs/empty/")
   suppressWarnings({
     suppressMessages({
-      expect_message(hub_con <- connect_hub(hub_path, skip_checks = TRUE), 
+      expect_message(hub_con <- connect_hub(hub_path, skip_checks = TRUE),
         "superseded URL"
       )
     })

--- a/tests/testthat/test-hub-connection.R
+++ b/tests/testthat/test-hub-connection.R
@@ -71,22 +71,33 @@ test_that("connect_hub works on a local simple forecasting hub with no csvs", {
 test_that("connect_hub returns empty list when model output folder is empty", {
   # Local
   hub_path <- system.file("testhubs/empty", package = "hubUtils")
-  expect_warning(connect_hub(hub_path))
-  hub_con <- suppressWarnings(connect_hub(hub_path))
+  suppressWarnings({
+    expect_warning(hub_con <- connect_hub(hub_path), "No files of file formats")
+  })
   attr(hub_con, "model_output_dir") <- "test/model_output_dir"
   attr(hub_con, "hub_path") <- "test/hub_path"
   expect_snapshot(hub_con)
 
   # S3
   hub_path <- s3_bucket("hubverse/hubutils/testhubs/empty/")
-  hub_con <- suppressWarnings(connect_hub(hub_path))
+  suppressWarnings({
+    suppressMessages({
+      expect_message(hub_con <- connect_hub(hub_path), "superseded URL")
+    })
+  })
   attr(hub_con, "model_output_dir") <- "test/model_output_dir"
   attr(hub_con, "hub_path") <- "test/hub_path"
   expect_snapshot(hub_con)
 
   # S3, skip_checks is TRUE
   hub_path <- s3_bucket("hubverse/hubutils/testhubs/empty/")
-  hub_con <- suppressWarnings(connect_hub(hub_path, skip_checks = TRUE))
+  suppressWarnings({
+    suppressMessages({
+      expect_message(hub_con <- connect_hub(hub_path, skip_checks = TRUE), 
+        "superseded URL"
+      )
+    })
+  })
   attr(hub_con, "model_output_dir") <- "test/model_output_dir"
   attr(hub_con, "hub_path") <- "test/hub_path"
   expect_snapshot(hub_con)
@@ -345,7 +356,9 @@ test_that("connect_hub works on S3 bucket simple forecasting hub on AWS", {
   # Simple forecasting Hub example ----
 
   hub_path <- s3_bucket("hubverse/hubutils/testhubs/simple/")
-  hub_con <- connect_hub(hub_path)
+  suppressMessages({
+    expect_message(hub_con <- connect_hub(hub_path), "superseded URL")
+  })
 
   # Tests that paths are assigned to attributes correctly
   expect_equal(
@@ -388,7 +401,11 @@ test_that("connect_hub works on S3 bucket simple parquet forecasting hub on AWS"
   # Simple forecasting Hub example ----
 
   hub_path <- s3_bucket("hubverse/hubutils/testhubs/parquet/")
-  hub_con <- connect_hub(hub_path, file_format = "parquet")
+  suppressMessages({
+    expect_message(hub_con <- connect_hub(hub_path, file_format = "parquet"),
+      "superseded URL"
+    )
+  })
 
   # Tests that paths are assigned to attributes correctly
   expect_equal(
@@ -442,7 +459,11 @@ test_that("connect_hub works on parquet-only hub when skip_checks is TRUE", {
 
   # S3
   hub_path <- s3_bucket("hubverse/hubutils/testhubs/parquet/")
-  hub_con <- connect_hub(hub_path, file_format = "parquet", skip_checks = TRUE)
+  suppressMessages({
+    expect_message({
+      hub_con <- connect_hub(hub_path, file_format = "parquet", skip_checks = TRUE)
+    }, "superseded URL")
+  })
 
   # Tests that paths are assigned to attributes correctly
   expect_equal(

--- a/tests/testthat/test-hub-connection.R
+++ b/tests/testthat/test-hub-connection.R
@@ -486,7 +486,7 @@ test_that("connect_hub & connect_model_output fail correctly", {
   expect_snapshot(connect_hub("random/hub/path"), error = TRUE)
   expect_snapshot(connect_model_output("random/model-output/"), error = TRUE)
 
-  temp_dir <- tempdir()
+  temp_dir <- withr::local_tempdir()
   expect_snapshot(connect_hub(temp_dir), error = TRUE)
 
   dir.create(fs::path(temp_dir, "hub-config"))


### PR DESCRIPTION
This PR updates the snapshot tests to reflect the fact that all config files now have the `config` class and that the URLs are automatically updated with a message.
It also uses `withr::local_tempdir()` instead of `tempdir()` so that the directory could be gracefully cleaned up after the test.

I had forgotten to open a dev version bumping PR, so that is included here.

- **Increment version number to 1.2.3.9000**
- **update snapshots for hubUtils 0.2.0**
- **use `withr::local_tempdir()` for tests**
- **update expectation for warning; test for hubUtils msg**
