### PR TITLE
Clarify function packages in the hubData code examples

### DIFF
--- a/.github/workflows/pkgdown-netlify-preview.yaml
+++ b/.github/workflows/pkgdown-netlify-preview.yaml
@@ -8,6 +8,12 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish Site (uncheck for a dry run)"
+        type: boolean
+        required: false
+        default: true
 
 name: pkgdown-pr-preview
 
@@ -22,7 +28,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
       NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-      isPush: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+      PUBLISH: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
     permissions:
       contents: write
       pull-requests: write
@@ -47,7 +53,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Deploy production to GitHub pages 🚀
-        if: contains(env.isPush, 'true')
+        if: contains(env.PUBLISH, 'true')
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           clean: false
@@ -62,7 +68,7 @@ jobs:
             echo 'dir=./docs' >> $GITHUB_OUTPUT
           fi
       - name: Deploy PR preview to Netlify
-        if: contains(env.isPush, 'false')
+        if: contains(env.PUBLISH, 'false')
         id: netlify-deploy
         uses: nwtgck/actions-netlify@v3
         with:

--- a/.github/workflows/pkgdown-netlify-preview.yaml
+++ b/.github/workflows/pkgdown-netlify-preview.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-tinytex@v2
 
@@ -53,13 +53,20 @@ jobs:
           clean: false
           branch: gh-pages
           folder: docs
-
+      - id: deploy-dir
+        name: Determine dev status
+        run: |
+          if [[ $(grep -c -E 'sion. ([0-9]*\.){3}' ${{ github.workspace }}/DESCRIPTION) == 1 ]]; then
+            echo 'dir=./docs/dev' >> $GITHUB_OUTPUT
+          else
+            echo 'dir=./docs' >> $GITHUB_OUTPUT
+          fi
       - name: Deploy PR preview to Netlify
         if: contains(env.isPush, 'false')
         id: netlify-deploy
-        uses: nwtgck/actions-netlify@v2
+        uses: nwtgck/actions-netlify@v3
         with:
-          publish-dir: './docs'
+          publish-dir: '${{ steps.deploy-dir.outputs.dir }}'
           production-branch: main
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message:

--- a/.lintr
+++ b/.lintr
@@ -1,9 +1,11 @@
 linters: linters_with_defaults(
     line_length_linter = line_length_linter(120L),
-    commented_code_linter = NULL
+    commented_code_linter = NULL,
+    return_linter = NULL
   )
 exclusions: list(
     "tests/testthat/test-create_hub_schema.R" = list(
       line_length_linter = Inf
     )
   )
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+exclude: >
+    (?x)(
+        ^tests/_snaps/|
+        ^tests/testthat/_snaps/|
+        ^tests/testthat/testdata/
+    )
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.6.0
+  hooks:
+  - id: trailing-whitespace
+  - id: check-yaml
+    args: [--allow-multiple-documents]
+  - id: detect-aws-credentials
+    args: [--allow-missing-credentials]
+  - id: detect-private-key
+- repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: v0.41.0
+  hooks:
+  - id: markdownlint
+    args: [ --fix, --disable=MD007, --disable=MD013, --disable=MD024, --disable=MD033, --disable=MD041 ]
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.3.0
+  hooks:
+  - id: codespell
+-   repo: https://github.com/lorenzwalthert/precommit
+    rev: v0.1.2
+    hooks:
+    - id: lintr
+      verbose: true
+      args: [--warn_only]
+
+
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,3 @@ repos:
     - id: lintr
       verbose: true
       args: [--warn_only]
-
-
-

--- a/vignettes/articles/connect_hub.Rmd
+++ b/vignettes/articles/connect_hub.Rmd
@@ -52,7 +52,7 @@ To connect to a local hub, supply the path to the hub to `connect_hub()`
 
 ```{r}
 hub_path <- system.file("testhubs/flusight", package = "hubUtils")
-hub_con <- connect_hub(hub_path)
+hub_con <- hubData::connect_hub(hub_path)
 hub_con
 ```
 
@@ -63,14 +63,14 @@ To connect to a hub in the cloud, first use one of the re-exported `arrow` helpe
 Then supply the resulting `*FileSystem` object to `connect_hub()`.
 
 ```{r}
-hub_path_cloud <- s3_bucket("hubverse/hubutils/testhubs/simple/")
-hub_con_cloud <- connect_hub(hub_path_cloud)
+hub_path_cloud <- arrow::s3_bucket("hubverse/hubutils/testhubs/simple/")
+hub_con_cloud <- hubData::connect_hub(hub_path_cloud)
 hub_con_cloud
 ```
 
 ### Performance considerations
 
-By default, `connect_hub` will ignore invalid files in the hub's model output directory when it creates a connection. This check prevents errors when working with the data, but it negatively impacts performance.
+By default, `connect_hub()` will ignore invalid files in the hub's model output directory when it creates a connection. This check prevents errors when working with the data, but it negatively impacts performance.
 
 If the cloud-based hub uses a single file type for model output data, you can improve performance by using the `skip_checks` argument. This argument will bypass the default behavior of scanning the hub's model output directory for invalid files before connecting.
 
@@ -80,8 +80,8 @@ Using this argument will fail unless the hub meets the following criteria:
 - the model output files use a single file format.
 
 ```{r}
-hub_path_cloud <- s3_bucket("hubverse/hubutils/testhubs/parquet/")
-hub_con_cloud <- connect_hub(hub_path_cloud, file_format = "parquet", skip_checks = TRUE)
+hub_path_cloud <- arrow::s3_bucket("hubverse/hubutils/testhubs/parquet/")
+hub_con_cloud <- hubData::connect_hub(hub_path_cloud, file_format = "parquet", skip_checks = TRUE)
 hub_con_cloud
 ```
 
@@ -92,8 +92,8 @@ To access data from a hub connection you can use dplyr verbs and construct query
 To perform the queries, you can use `dplyr`'s `collect()` function:
 ```{r}
 hub_con %>%
-  filter(output_type == "quantile", location == "US") %>%
-  collect()
+  dplyr::filter(output_type == "quantile", location == "US") %>%
+  dplyr::collect()
 ```
 
 Note however that in the above example, while the output contains the required `model_id`, `output_type`, `output_type_id` and `value` columns for a `model_out_tbl` object, it is returned as a `tbl_df` or `tibble` object and the order of the columns is not standardised.
@@ -104,8 +104,8 @@ Conveniently, you can use the `hubData` wrapper `collect_hub()` which converts t
 
 ```{r}
 tbl <- hub_con %>%
-  filter(output_type == "quantile", location == "US") %>%
-  collect_hub()
+  dplyr::filter(output_type == "quantile", location == "US") %>%
+  hubData::collect_hub()
 
 tbl
 
@@ -118,8 +118,8 @@ Accessing data from hubs in the cloud is exactly the same:
 
 ```{r}
 hub_con_cloud %>%
-  filter(output_type == "quantile", location == "US") %>%
-  collect_hub()
+  dplyr::filter(output_type == "quantile", location == "US") %>%
+  hubData::collect_hub()
 ```
 
 ## Limitations of `dplyr` queries on `arrow` datasets
@@ -130,11 +130,11 @@ For example, if you wanted to get all quantile predictions for the last forecast
 
 ```{r, error=TRUE}
 hub_con %>%
-  filter(
+  dplyr::filter(
     output_type == "quantile", location == "US",
     forecast_date == max(forecast_date, na.rm = TRUE)
   ) %>%
-  collect_hub()
+  hubData::collect_hub()
 ```
 
 This doesn't work however as `arrow` does not have an equivalent `max` method for `Date[32]` data types.
@@ -143,9 +143,9 @@ In such a situation, you could collect after applying the first filtering level 
 
 ```{r}
 hub_con %>%
-  filter(output_type == "quantile", location == "US") %>%
-  collect_hub() %>%
-  filter(forecast_date == max(forecast_date))
+  dplyr::filter(output_type == "quantile", location == "US") %>%
+  hubData::collect_hub() %>%
+  dplyr::filter(forecast_date == max(forecast_date))
 ```
 
 Alternatively, depending on the size of the data, in might be quicker to filter the data in two steps:
@@ -155,17 +155,17 @@ Alternatively, depending on the size of the data, in might be quicker to filter 
 
 ```{r}
 last_forecast <- hub_con %>%
-  filter(output_type == "quantile", location == "US") %>%
-  pull(forecast_date, as_vector = TRUE) %>%
-  max(na.rm = TRUE)
+  dplyr::filter(output_type == "quantile", location == "US") %>%
+  dplyr::pull(forecast_date, as_vector = TRUE) %>%
+  dplyr::max(na.rm = TRUE)
 
 
 hub_con %>%
-  filter(
+  dplyr::filter(
     output_type == "quantile", location == "US",
     forecast_date == last_forecast
   ) %>%
-  collect_hub()
+  hubData::collect_hub()
 ```
 
 ### Use `arrow::to_duckdb()` to extend available queries 
@@ -177,11 +177,11 @@ _For more details see [DuckDB quacks Arrow: A zero-copy data integration between
 ```{r}
 hub_con %>%
   arrow::to_duckdb() %>%
-  filter(
+  dplyr::filter(
     output_type == "quantile", location == "US",
     forecast_date == max(forecast_date, na.rm = TRUE)
   ) %>%
-  collect_hub()
+  hubData::collect_hub()
 ```
 
 
@@ -195,7 +195,7 @@ In addition, only a single file_format dataset can be opened.
 
 ```{r}
 model_output_dir <- system.file("testhubs/simple/model-output", package = "hubUtils")
-mod_out_con <- connect_model_output(model_output_dir, file_format = "csv")
+mod_out_con <- hubData::connect_model_output(model_output_dir, file_format = "csv")
 mod_out_con
 ```
 
@@ -203,28 +203,28 @@ Accessing data follows the same procedure described for fully configured hubs:
 
 ```{r}
 mod_out_con %>%
-  filter(output_type == "quantile", location == "US") %>%
-  collect_hub()
+  dplyr::filter(output_type == "quantile", location == "US") %>%
+  hubData::collect_hub()
 ```
 
 And connecting to cloud model output data follows the same procedure described for fully configured cloud hubs:
 
 ```{r}
-mod_out_dir_cloud <- s3_bucket(
+mod_out_dir_cloud <- arrow::s3_bucket(
   "hubverse/hubutils/testhubs/simple/model-output/"
 )
-mod_out_con_cloud <- connect_model_output(
+mod_out_con_cloud <- hubData::connect_model_output(
   mod_out_dir_cloud,
   file_format = "csv"
 )
 mod_out_con_cloud
 ```
 
-Like `connect_hub`, `connect_model_output` has an optional `skip_checks` argument that improves performance:
+Like `connect_hub()`, `connect_model_output()` has an optional `skip_checks` argument that improves performance:
 
 ```{r}
-mod_out_dir_cloud <- s3_bucket("hubverse/hubutils/testhubs/parquet/model-output/")
-mod_out_con_cloud <- connect_model_output(mod_out_dir_cloud, file_format = "parquet", skip_checks = TRUE)
+mod_out_dir_cloud <- arrow::s3_bucket("hubverse/hubutils/testhubs/parquet/model-output/")
+mod_out_con_cloud <- hubData::connect_model_output(mod_out_dir_cloud, file_format = "parquet", skip_checks = TRUE)
 mod_out_con_cloud
 ```
 
@@ -235,7 +235,7 @@ When connecting to a model output directly, you can also specify a schema to ove
 ```{r}
 library(arrow)
 
-model_output_schema <- schema(
+model_output_schema <- arrow::schema(
   origin_date = date32(),
   target = string(),
   horizon = int32(),
@@ -246,7 +246,7 @@ model_output_schema <- schema(
   model_id = string()
 )
 
-mod_out_con <- connect_model_output(model_output_dir,
+mod_out_con <- hubData::connect_model_output(model_output_dir,
   file_format = "csv",
   schema = model_output_schema
 )
@@ -257,7 +257,7 @@ Using a schema can however also produce new errors which can sometimes be hard t
 
 
 ```{r, error=TRUE}
-model_output_schema <- schema(
+model_output_schema <- arrow::schema(
   origin_date = date32(),
   target = string(),
   horizon = int32(),
@@ -268,7 +268,7 @@ model_output_schema <- schema(
   model_id = string()
 )
 
-mod_out_con <- connect_model_output(model_output_dir,
+mod_out_con <- hubData::connect_model_output(model_output_dir,
   file_format = "csv",
   schema = model_output_schema
 )

--- a/vignettes/articles/connect_hub.Rmd
+++ b/vignettes/articles/connect_hub.Rmd
@@ -63,7 +63,7 @@ To connect to a hub in the cloud, first use one of the re-exported `arrow` helpe
 Then supply the resulting `*FileSystem` object to `connect_hub()`.
 
 ```{r}
-hub_path_cloud <- arrow::s3_bucket("hubverse/hubutils/testhubs/simple/")
+hub_path_cloud <- hubData::s3_bucket("hubverse/hubutils/testhubs/simple/")
 hub_con_cloud <- hubData::connect_hub(hub_path_cloud)
 hub_con_cloud
 ```
@@ -80,7 +80,7 @@ Using this argument will fail unless the hub meets the following criteria:
 - the model output files use a single file format.
 
 ```{r}
-hub_path_cloud <- arrow::s3_bucket("hubverse/hubutils/testhubs/parquet/")
+hub_path_cloud <- hubData::s3_bucket("hubverse/hubutils/testhubs/parquet/")
 hub_con_cloud <- hubData::connect_hub(hub_path_cloud, file_format = "parquet", skip_checks = TRUE)
 hub_con_cloud
 ```
@@ -210,7 +210,7 @@ mod_out_con %>%
 And connecting to cloud model output data follows the same procedure described for fully configured cloud hubs:
 
 ```{r}
-mod_out_dir_cloud <- arrow::s3_bucket(
+mod_out_dir_cloud <- hubData::s3_bucket(
   "hubverse/hubutils/testhubs/simple/model-output/"
 )
 mod_out_con_cloud <- hubData::connect_model_output(
@@ -223,7 +223,7 @@ mod_out_con_cloud
 Like `connect_hub()`, `connect_model_output()` has an optional `skip_checks` argument that improves performance:
 
 ```{r}
-mod_out_dir_cloud <- arrow::s3_bucket("hubverse/hubutils/testhubs/parquet/model-output/")
+mod_out_dir_cloud <- hubData::s3_bucket("hubverse/hubutils/testhubs/parquet/model-output/")
 mod_out_con_cloud <- hubData::connect_model_output(mod_out_dir_cloud, file_format = "parquet", skip_checks = TRUE)
 mod_out_con_cloud
 ```

--- a/vignettes/articles/connect_hub.Rmd
+++ b/vignettes/articles/connect_hub.Rmd
@@ -30,11 +30,11 @@ There are two functions for connecting to `model-output` data:
 - `connect_hub()` is used for connecting to fully configured hubs (i.e. which contain valid `admin.json` and `tasks.json` in a `hub-config` directory). This function uses configurations defined in config files in the `hub-config/` directory and allows for connecting to hubs with files in multiple file formats (allowable formats specified by the `file_format` property of `admin.json`).
 - `connect_model_output()` allows for connecting directly to the contents of a `model-output` directory and is useful for connecting to appropriately organised files in an informal hub (i.e. which has not been fully configured with appropriate `hub-config/` files.)
 
-Both functions establish connections through the [`arrow`](https://arrow.apache.org/docs/r/) package, specifically by opening datasets as [`FileSystemDataset`s](https://arrow.apache.org/docs/r/reference/Dataset.html), one for each file format. 
+Both functions establish connections through the [`arrow`](https://arrow.apache.org/docs/r/) package, specifically by opening datasets as [`FileSystemDataset`s](https://arrow.apache.org/docs/r/reference/Dataset.html), one for each file format.
 Both functions are also able to connect to files that are stored locally or in the cloud (e.g. in AWS S3 buckets).
 
-Where multiple file formats are accepted in a single Hub, file format specific `FileSystemDataset`s are combined into a single `UnionDataset` for single point access to the entire Hub `model-output` dataset. 
-This only applies to `connect_hub()` in fully configured Hubs, where config files can be used to determine a unifying schema across all file formats. 
+Where multiple file formats are accepted in a single Hub, file format specific `FileSystemDataset`s are combined into a single `UnionDataset` for single point access to the entire Hub `model-output` dataset.
+This only applies to `connect_hub()` in fully configured Hubs, where config files can be used to determine a unifying schema across all file formats.
 
 In contrast, `connect_model_output()` can only be used to open single file format datasets of the format defined explicitly through the `file_format` argument.
 
@@ -157,7 +157,7 @@ Alternatively, depending on the size of the data, in might be quicker to filter 
 last_forecast <- hub_con %>%
   dplyr::filter(output_type == "quantile", location == "US") %>%
   dplyr::pull(forecast_date, as_vector = TRUE) %>%
-  dplyr::max(na.rm = TRUE)
+  max(na.rm = TRUE)
 
 
 hub_con %>%
@@ -168,7 +168,7 @@ hub_con %>%
   hubData::collect_hub()
 ```
 
-### Use `arrow::to_duckdb()` to extend available queries 
+### Use `arrow::to_duckdb()` to extend available queries
 
 You could alternatively use `arrow::to_duckdb()` to first convert the dataset connection to an in memory virtual DuckDB table. This will allows you to run queries that are supported by DuckDB but not by arrow, extending the potential queries that can be run against hub data before collecting.
 
@@ -187,7 +187,7 @@ hub_con %>%
 
 # Connecting to a model output directory
 
-There is also an option to connect directly to a model output directory without using any metadata in a hub config file. This can be useful when a hub has not been fully configured yet. 
+There is also an option to connect directly to a model output directory without using any metadata in a hub config file. This can be useful when a hub has not been fully configured yet.
 
 The approach does have certain limitations though. For example, an overall unifying schema cannot be determined from the config files so the ability of `open_dataset()` to connect and parse data correctly cannot be guaranteed across files.
 
@@ -228,7 +228,7 @@ mod_out_con_cloud <- hubData::connect_model_output(mod_out_dir_cloud, file_forma
 mod_out_con_cloud
 ```
 
-## Providing a custom schema 
+## Providing a custom schema
 
 When connecting to a model output directly, you can also specify a schema to override the default arrow schema auto-detection. This can help at times to resolve conflicts in data types across different dataset files.
 
@@ -253,7 +253,7 @@ mod_out_con <- hubData::connect_model_output(model_output_dir,
 mod_out_con
 ```
 
-Using a schema can however also produce new errors which can sometimes be hard to debug. For example, here we are defining a schema with field `output_type` cast as `int32` data type. As column `output_type` actually contain character type data which cannot be coerced to integer, connecting to the model output directory produces an `arrow` error. 
+Using a schema can however also produce new errors which can sometimes be hard to debug. For example, here we are defining a schema with field `output_type` cast as `int32` data type. As column `output_type` actually contain character type data which cannot be coerced to integer, connecting to the model output directory produces an `arrow` error.
 
 
 ```{r, error=TRUE}

--- a/vignettes/articles/connect_hub.Rmd
+++ b/vignettes/articles/connect_hub.Rmd
@@ -70,9 +70,12 @@ hub_con_cloud
 
 ### Performance considerations
 
-By default, `connect_hub()` will ignore invalid files in the hub's model output directory when it creates a connection. This check prevents errors when working with the data, but it negatively impacts performance.
+By default, `connect_hub()` will ignore invalid files in the hub's model output directory when it creates a connection.
+This check prevents errors when working with the data, but it negatively impacts performance.
 
-If the cloud-based hub uses a single file type for model output data, you can improve performance by using the `skip_checks` argument. This argument will bypass the default behavior of scanning the hub's model output directory for invalid files before connecting.
+If the cloud-based hub uses a single file type for model output data, you can improve performance by using the
+`skip_checks` argument. This argument will bypass the default behavior of scanning the hub's model output directory for
+invalid files before connecting.
 
 Using this argument will fail unless the hub meets the following criteria:
 


### PR DESCRIPTION
Closes #68 

Add package names to the functions used in hubData examples. This will prevent wayward R users from mixing up dplyr functions such as `filter` with base R functions of the same name.

It seems unlikely that someone would get mixed up like that, but better safe than sorry.