### PR TITLE
Add security updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# require core team member review for updates to GitHub workflows
+/.github/CODEOWNERS @hubverse-org/hubverse-developers
+/.github/actions/ @hubverse-org/hubverse-developers
+/.github/shared/ @hubverse-org/hubverse-developers
+/.github/workflows/ @hubverse-org/hubverse-developers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# instruct GitHub dependabot to scan github actions for updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # dependabot automatically checks .github/workflows/ and .github/actions/
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # group all run-of-the mill updates into a single pull request
+    groups:
+      updates:
+        applies-to: version-updates
+        update-types:
+          - patch
+          - minor

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -47,10 +47,10 @@ jobs:
           sed -i -e '/  hubverse-org/d' DESCRIPTION
 
       - id: setup-pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 #v2.11.3
 
       - id: setup-r
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 #v2.11.3
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
@@ -58,12 +58,12 @@ jobs:
           extra-repositories: https://hubverse-org.r-universe.dev
 
       - id: fetch-dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
+        uses: r-lib/actions/setup-r-dependencies@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 #v2.11.3
         with:
           extra-packages: any::rcmdcheck
           needs: check
 
       - id: check
-        uses: r-lib/actions/check-r-package@v2
+        uses: r-lib/actions/check-r-package@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 #v2.11.3
         with:
           upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -11,6 +11,9 @@ on:
 
 name: R-CMD-check
 
+permissions:
+  contents: read
+
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,6 +8,9 @@ on:
 
 name: lint
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,11 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 #v2.11.3
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 #v2.11.3
         with:
           extra-packages: any::lintr, local::.
           needs: lint

--- a/.github/workflows/pkgdown-netlify-preview.yaml
+++ b/.github/workflows/pkgdown-netlify-preview.yaml
@@ -35,15 +35,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-tinytex@v2
+      - uses: r-lib/actions/setup-tinytex@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 #v2.11.3
 
-      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-pandoc@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 #v2.11.3
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 #v2.11.3
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 #v2.11.3
         with:
           extra-packages: any::pkgdown, local::.
           needs: website
@@ -54,7 +54,7 @@ jobs:
 
       - name: Deploy production to GitHub pages 🚀
         if: contains(env.PUBLISH, 'true')
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8 #v4.7.3
         with:
           clean: false
           branch: gh-pages
@@ -70,7 +70,7 @@ jobs:
       - name: Deploy PR preview to Netlify
         if: contains(env.PUBLISH, 'false')
         id: netlify-deploy
-        uses: nwtgck/actions-netlify@v3
+        uses: nwtgck/actions-netlify@4cbaf4c08f1a7bfa537d6113472ef4424e4eb654 #v3.0.0
         with:
           publish-dir: '${{ steps.deploy-dir.outputs.dir }}'
           production-branch: main

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -20,12 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 #v2.11.3
         with:
           use-public-rspm: true
           extra-repositories: https://hubverse-org.r-universe.dev
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 #v2.11.3
         with:
           extra-packages: any::covr
           needs: coverage

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -8,6 +8,9 @@ on:
 
 name: test-coverage
 
+permissions:
+  contents: read
+
 jobs:
   test-coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #79 

This PR can be reviewed commit by commit and does the following:

- Add CODEOWNERS to monitor GitHub workflow updates
 - Set up Dependabot to flag updates to GitHub actions
 - Pin 3rd party GitHub actions via commit SHA
 - Add explicit permissions to workflows

In addition to the changes in this PR, an admin of this repo should update the CodeQL scanning rulesets as documented here: https://hubverse.io/en/latest/developer/security.html#codeql-settings
