### PR TITLE
Update links to docs.hubverse.io

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -38,11 +38,11 @@ Examples of unacceptable behavior include:
 
 ## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying our standards of acceptable behavior. Enforcement is the responsibility of the [Code of Conduct Committee](https://hubverse.io/en/latest/coc/committee.html), who will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. 
+Community leaders are responsible for clarifying our standards of acceptable behavior. Enforcement is the responsibility of the [Code of Conduct Committee](https://docs.hubverse.io/en/latest/coc/committee.html), who will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. 
 
-Instances of abusive, harassing, or otherwise unacceptable behavior [may be reported to any member of the Code of Conduct Committee](https://hubverse.io/en/latest/coc/committee.html). All complaints will be reviewed and investigated promptly and fairly. 
+Instances of abusive, harassing, or otherwise unacceptable behavior [may be reported to any member of the Code of Conduct Committee](https://docs.hubverse.io/en/latest/coc/committee.html). All complaints will be reviewed and investigated promptly and fairly. 
 
-The Code of Conduct Committee will use the [Enforcement Manual](https://hubverse.io/en/latest/coc/enforcement-manual.html) in determining the consequences for any action they deem in violation of this Code of Conduct. All community leaders and Code of Conduct Committee members are obligated to respect the privacy and security of the reporter of any incident.
+The Code of Conduct Committee will use the [Enforcement Manual](https://docs.hubverse.io/en/latest/coc/enforcement-manual.html) in determining the consequences for any action they deem in violation of this Code of Conduct. All community leaders and Code of Conduct Committee members are obligated to respect the privacy and security of the reporter of any incident.
 
 
 ## Scope

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 This outlines how to propose a change to `hubData`.
 For more general info about contributing to this, and other hubverse packages, please see the
-[**hubverse contributing guide**](https://hubverse.io/en/latest/overview/contribute.html).
+[**hubverse contributing guide**](https://docs.hubverse.io/en/latest/overview/contribute.html).
 
 You can fix typos, spelling mistakes, or grammatical errors in the documentation directly using the GitHub web interface, as long as the changes are made in the *source* file.
 This generally means you'll need to edit [roxygen2 comments](https://roxygen2.r-lib.org/articles/roxygen2.html) in an `.R`, not a `.Rd` file.

--- a/README.Rmd
+++ b/README.Rmd
@@ -25,7 +25,7 @@ knitr::opts_chunk$set(
 
 The goal of hubData is to provide tools for accessing and working with hubverse Hub data.
 
-This package is part of the [hubverse](https://hubverse.io/en/latest/) ecosystem, which aims to provide a set of tools for infectious disease modeling hubs to share and collaborate on their work.
+This package is part of the [hubverse](https://hubverse.io) ecosystem, which aims to provide a set of tools for infectious disease modeling hubs to share and collaborate on their work.
 
 ## Installation
 
@@ -65,6 +65,6 @@ Please note that the hubData package is released with a [Contributor Code of Con
 ## Contributing
 
 Interested in contributing back to the open-source Hubverse project?
-Learn more about how to [get involved in the Hubverse Community](https://hubverse.io/en/latest/overview/contribute.html) or [how to contribute to the hubData package](.github/CONTRIBUTING.md).
+Learn more about how to [get involved in the Hubverse Community](https://docs.hubverse.io/en/latest/overview/contribute.html) or [how to contribute to the hubData package](.github/CONTRIBUTING.md).
 
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ status](https://www.r-pkg.org/badges/version/hubData)](https://CRAN.R-project.or
 The goal of hubData is to provide tools for accessing and working with
 hubverse Hub data.
 
-This package is part of the [hubverse](https://hubverse.io/en/latest/)
+This package is part of the [hubverse](https://hubverse.io)
 ecosystem, which aims to provide a set of tools for infectious disease
 modeling hubs to share and collaborate on their work.
 
@@ -67,5 +67,5 @@ project, you agree to abide by its terms.
 
 Interested in contributing back to the open-source Hubverse project?
 Learn more about how to [get involved in the Hubverse
-Community](https://hubverse.io/en/latest/overview/contribute.html) or
+Community](https://docs.hubverse.io/en/latest/overview/contribute.html) or
 [how to contribute to the hubData package](.github/CONTRIBUTING.md).

--- a/vignettes/articles/connect_hub.Rmd
+++ b/vignettes/articles/connect_hub.Rmd
@@ -13,7 +13,7 @@ An important function of `hubData` is allowing for the connection to data in the
 
 # Structure of hubverse datasets
 
-All data returned from connecting to and querying hubs can be read or validated as a `model_out_tbl` which is a foundational S3 class in the hubverse ecosystem. A `model_out_tbl` is a long-form [`tibble`](https://tibble.tidyverse.org/) designed to conform to the [hubverse data specifications for model output data](https://hubverse.io/en/latest/user-guide/model-output.html). In short, the columns of a valid `model_out_tbl` containing model output data from a hub are:
+All data returned from connecting to and querying hubs can be read or validated as a `model_out_tbl` which is a foundational S3 class in the hubverse ecosystem. A `model_out_tbl` is a long-form [`tibble`](https://tibble.tidyverse.org/) designed to conform to the [hubverse data specifications for model output data](https://docs.hubverse.io/en/latest/user-guide/model-output.html). In short, the columns of a valid `model_out_tbl` containing model output data from a hub are:
 
  - `model_id`: this is the unique character identifier of a model.
  - `output_type`: a character variable that defines the type of representation of model output that is in a given row.


### PR DESCRIPTION
This PR updates `hubverse.io` URLs to point to `docs.hubverse.io`.

📝 Multiple commits — feel free to **Squash and Merge** to keep history clean.