### PR TITLE
Add option to return R data type version of schema

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,5 +54,5 @@ Remotes:
     hubverse-org/hubUtils
 Config/Needs/website: hubverse-org/hubStyle
 Depends: 
-    R (>= 2.10)
+    R (>= 4.1)
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # hubData (development version)
 
+* Added `r_schema` argument to `create_timeseries_schema()` and `create_oracle_output_schema()` functions to enable returning the schema as a vector of R data types instead of an `arrow::Schema` object (#95)
+* Added `output_type_id_datatype` argument to `create_oracle_output_schema()` and `connect_target_oracle_output()` functions to allow users to explicitly specify the data type of the `output_type_id` column in the schema. This ensuring compatibility with `create_hub_schema()` and `connect_hub()` (#95).
+
 # hubData 1.4.0
 
 * Added `connect_target_timeseries()` function (experimental) for accessing time-series target data from a hub (#71). This includes accessing target data from cloud hubs (#75).

--- a/R/connect_target_oracle.R
+++ b/R/connect_target_oracle.R
@@ -38,12 +38,18 @@
 #' s3_con <- connect_target_oracle_output(s3_hub_path)
 #' s3_con
 #' s3_con |> dplyr::collect()
-connect_target_oracle_output <- function(hub_path = ".", na = c("NA", ""),
-                                         ignore_files = NULL) {
+connect_target_oracle_output <- function(
+  hub_path = ".",
+  na = c("NA", ""),
+  ignore_files = NULL,
+) {
   ignore_files <- unique(c(ignore_files, "README", ".DS_Store"))
   oo_path <- validate_target_data_path(hub_path, "oracle-output")
   oo_ext <- get_target_file_ext(hub_path, oo_path)
-  oo_schema <- create_oracle_output_schema(hub_path, ignore_files = ignore_files)
+  oo_schema <- create_oracle_output_schema(
+    hub_path,
+    ignore_files = ignore_files,
+  )
   if (inherits(hub_path, "SubTreeFileSystem")) {
     # We create URI paths for cloud storage to ensure we can open single file
     # data correctly.
@@ -56,11 +62,14 @@ connect_target_oracle_output <- function(hub_path = ".", na = c("NA", ""),
 
   oo_data <- open_target_dataset(
     oo_path,
-    ext = oo_ext, schema = oo_schema,
-    na = na, ignore_files = ignore_files
+    ext = oo_ext,
+    schema = oo_schema,
+    na = na,
+    ignore_files = ignore_files
   )
 
-  structure(oo_data,
+  structure(
+    oo_data,
     class = c("target_oracle_output", class(oo_data)),
     oo_path = out_path,
     hub_path = hub_path

--- a/R/connect_target_oracle.R
+++ b/R/connect_target_oracle.R
@@ -42,13 +42,24 @@ connect_target_oracle_output <- function(
   hub_path = ".",
   na = c("NA", ""),
   ignore_files = NULL,
+  output_type_id_datatype = c(
+    "from_config",
+    "auto",
+    "character",
+    "double",
+    "integer",
+    "logical",
+    "Date"
+  )
 ) {
+  output_type_id_datatype <- rlang::arg_match(output_type_id_datatype)
   ignore_files <- unique(c(ignore_files, "README", ".DS_Store"))
   oo_path <- validate_target_data_path(hub_path, "oracle-output")
   oo_ext <- get_target_file_ext(hub_path, oo_path)
   oo_schema <- create_oracle_output_schema(
     hub_path,
     ignore_files = ignore_files,
+    output_type_id_datatype = output_type_id_datatype
   )
   if (inherits(hub_path, "SubTreeFileSystem")) {
     # We create URI paths for cloud storage to ensure we can open single file

--- a/R/create_oracle_output_schema.R
+++ b/R/create_oracle_output_schema.R
@@ -21,13 +21,26 @@ create_oracle_output_schema <- function(
   hub_path,
   na = c("NA", ""),
   ignore_files = NULL,
-  r_schema = FALSE
+  r_schema = FALSE,
+  output_type_id_datatype = c(
+    "from_config",
+    "auto",
+    "character",
+    "double",
+    "integer",
+    "logical",
+    "Date"
+  )
 ) {
+  output_type_id_datatype <- rlang::arg_match(output_type_id_datatype)
   ignore_files <- unique(c(ignore_files, "README", ".DS_Store"))
   oo_path <- validate_target_data_path(hub_path, "oracle-output")
 
   config_tasks <- read_config(hub_path)
-  hub_schema <- create_hub_schema(config_tasks)
+  hub_schema <- create_hub_schema(
+    config_tasks,
+    output_type_id_datatype = output_type_id_datatype
+  )
 
   oo_ext <- validate_target_file_ext(oo_path, hub_path)
   if (inherits(hub_path, "SubTreeFileSystem")) {

--- a/R/create_timeseries_schema.R
+++ b/R/create_timeseries_schema.R
@@ -19,9 +19,12 @@
 #' #  target time-series schema from a cloud hub
 #' s3_hub_path <- s3_bucket("example-complex-forecast-hub")
 #' create_timeseries_schema(s3_hub_path)
-create_timeseries_schema <- function(hub_path, date_col = NULL,
-                                     na = c("NA", ""),
-                                     ignore_files = NULL) {
+create_timeseries_schema <- function(
+  hub_path,
+  date_col = NULL,
+  na = c("NA", ""),
+  ignore_files = NULL
+) {
   ignore_files <- unique(c(ignore_files, "README", ".DS_Store"))
   ts_path <- validate_target_data_path(hub_path, "time-series")
 
@@ -45,7 +48,9 @@ create_timeseries_schema <- function(hub_path, date_col = NULL,
   ts_schema[["observation"]] <- hub_schema[["value"]]$type
 
   missing <- setdiff(file_schema$names, ts_schema$names)
-  ts_schema <- arrow::schema(!!!c(ts_schema$fields, file_schema[missing]$fields))
+  ts_schema <- arrow::schema(
+    !!!c(ts_schema$fields, file_schema[missing]$fields)
+  )
 
   if (!is.null(date_col)) {
     checkmate::assert_character(date_col, len = 1L)

--- a/R/create_timeseries_schema.R
+++ b/R/create_timeseries_schema.R
@@ -105,6 +105,6 @@ as_r_schema <- function(arrow_schema) {
       arrow_schema$fields,
       names(arrow_schema)
     ),
-    ~ r_datatypes[[.x$type$ToString()]]
+    \(.x) r_datatypes[[.x$type$ToString()]]
   )
 }

--- a/man/connect_target_oracle_output.Rd
+++ b/man/connect_target_oracle_output.Rd
@@ -7,7 +7,9 @@
 connect_target_oracle_output(
   hub_path = ".",
   na = c("NA", ""),
-  ignore_files = NULL
+  ignore_files = NULL,
+  output_type_id_datatype = c("from_config", "auto", "character", "double", "integer",
+    "logical", "Date")
 )
 }
 \arguments{
@@ -32,6 +34,23 @@ include in dataset connections.
 Parent directory names should not be included.
 Common non-data files such as \code{"README"} and \code{".DS_Store"} are ignored automatically,
 but additional files can be excluded by specifying them here.}
+
+\item{output_type_id_datatype}{character string. One of \code{"from_config"}, \code{"auto"},
+\code{"character"}, \code{"double"}, \code{"integer"}, \code{"logical"}, \code{"Date"}.
+Defaults to \code{"from_config"} which uses the setting in the \code{output_type_id_datatype}
+property in the \code{tasks.json} config file if available. If the property is
+not set in the config, the argument falls back to \code{"auto"} which determines
+the  \code{output_type_id} data type automatically from the \code{tasks.json}
+config file as the simplest data type required to represent all output
+type ID values across all output types in the hub.
+When only point estimate output types (where \code{output_type_id}s are \code{NA},) are
+being collected by a hub, the \code{output_type_id} column is assigned a \code{character}
+data type when auto-determined.
+Other data type values can be used to override automatic determination.
+Note that attempting to coerce \code{output_type_id} to a data type that is
+not valid for the data (e.g. trying to coerce\code{"character"} values to
+\code{"double"}) will likely result in an error or potentially unexpected
+behaviour so use with care.}
 }
 \value{
 An arrow dataset object of subclass <target_oracle_output>.

--- a/man/create_oracle_output_schema.Rd
+++ b/man/create_oracle_output_schema.Rd
@@ -4,7 +4,12 @@
 \alias{create_oracle_output_schema}
 \title{Create oracle-output target data file schema}
 \usage{
-create_oracle_output_schema(hub_path, na = c("NA", ""), ignore_files = NULL)
+create_oracle_output_schema(
+  hub_path,
+  na = c("NA", ""),
+  ignore_files = NULL,
+  r_schema = FALSE
+)
 }
 \arguments{
 \item{hub_path}{Either a character string path to a local Modeling Hub directory
@@ -28,6 +33,9 @@ include in dataset connections.
 Parent directory names should not be included.
 Common non-data files such as \code{"README"} and \code{".DS_Store"} are ignored automatically,
 but additional files can be excluded by specifying them here.}
+
+\item{r_schema}{Logical. If \code{FALSE} (default), return an \code{\link[arrow:schema]{arrow::schema()}} object.
+If \code{TRUE}, return a character vector of R data types.}
 }
 \value{
 an arrow \verb{<schema>} class object

--- a/man/create_oracle_output_schema.Rd
+++ b/man/create_oracle_output_schema.Rd
@@ -8,7 +8,9 @@ create_oracle_output_schema(
   hub_path,
   na = c("NA", ""),
   ignore_files = NULL,
-  r_schema = FALSE
+  r_schema = FALSE,
+  output_type_id_datatype = c("from_config", "auto", "character", "double", "integer",
+    "logical", "Date")
 )
 }
 \arguments{
@@ -36,6 +38,23 @@ but additional files can be excluded by specifying them here.}
 
 \item{r_schema}{Logical. If \code{FALSE} (default), return an \code{\link[arrow:schema]{arrow::schema()}} object.
 If \code{TRUE}, return a character vector of R data types.}
+
+\item{output_type_id_datatype}{character string. One of \code{"from_config"}, \code{"auto"},
+\code{"character"}, \code{"double"}, \code{"integer"}, \code{"logical"}, \code{"Date"}.
+Defaults to \code{"from_config"} which uses the setting in the \code{output_type_id_datatype}
+property in the \code{tasks.json} config file if available. If the property is
+not set in the config, the argument falls back to \code{"auto"} which determines
+the  \code{output_type_id} data type automatically from the \code{tasks.json}
+config file as the simplest data type required to represent all output
+type ID values across all output types in the hub.
+When only point estimate output types (where \code{output_type_id}s are \code{NA},) are
+being collected by a hub, the \code{output_type_id} column is assigned a \code{character}
+data type when auto-determined.
+Other data type values can be used to override automatic determination.
+Note that attempting to coerce \code{output_type_id} to a data type that is
+not valid for the data (e.g. trying to coerce\code{"character"} values to
+\code{"double"}) will likely result in an error or potentially unexpected
+behaviour so use with care.}
 }
 \value{
 an arrow \verb{<schema>} class object

--- a/man/create_timeseries_schema.Rd
+++ b/man/create_timeseries_schema.Rd
@@ -8,7 +8,8 @@ create_timeseries_schema(
   hub_path,
   date_col = NULL,
   na = c("NA", ""),
-  ignore_files = NULL
+  ignore_files = NULL,
+  r_schema = FALSE
 )
 }
 \arguments{
@@ -37,6 +38,9 @@ include in dataset connections.
 Parent directory names should not be included.
 Common non-data files such as \code{"README"} and \code{".DS_Store"} are ignored automatically,
 but additional files can be excluded by specifying them here.}
+
+\item{r_schema}{Logical. If \code{FALSE} (default), return an \code{\link[arrow:schema]{arrow::schema()}} object.
+If \code{TRUE}, return a character vector of R data types.}
 }
 \value{
 an arrow \verb{<schema>} class object

--- a/tests/testthat/test-connect_target_oracle.R
+++ b/tests/testthat/test-connect_target_oracle.R
@@ -12,9 +12,13 @@ test_that("connect_target_oracle_output on single file works on local hub", {
   skip_if_offline()
   # Connect to oracle-output data
   oo_con <- connect_target_oracle_output(oo_hub_path)
-  expect_s3_class(oo_con,
+  expect_s3_class(
+    oo_con,
     c(
-      "target_oracle_output", "FileSystemDataset", "Dataset", "ArrowObject",
+      "target_oracle_output",
+      "FileSystemDataset",
+      "Dataset",
+      "ArrowObject",
       "R6"
     ),
     exact = TRUE
@@ -38,23 +42,81 @@ test_that("connect_target_oracle_output on single file works on local hub", {
 
   expect_equal(dim(all), c(200340L, 6L))
   expect_s3_class(all, "tbl_df", exact = FALSE)
-  expect_true(all[all$output_type_id == "quantile", ]$output_type_id |> is.na() |> all())
-  expect_equal(names(all), c(
-    "location", "target_end_date", "target",
-    "output_type", "output_type_id", "oracle_value"
-  ))
+  expect_true(
+    all[all$output_type_id == "quantile", ]$output_type_id |> is.na() |> all()
+  )
   expect_equal(
-    unique(all$location),
+    names(all),
     c(
-      "US", "01", "02", "04", "05", "06", "08", "09", "10", "11",
-      "12", "13", "15", "16", "17", "18", "19", "20", "21", "22", "23",
-      "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34",
-      "35", "36", "37", "38", "39", "40", "41", "42", "44", "45", "46",
-      "47", "48", "49", "50", "51", "53", "54", "55", "56", "72"
+      "location",
+      "target_end_date",
+      "target",
+      "output_type",
+      "output_type_id",
+      "oracle_value"
     )
   )
   expect_equal(
-    unique(all$target), c(
+    unique(all$location),
+    c(
+      "US",
+      "01",
+      "02",
+      "04",
+      "05",
+      "06",
+      "08",
+      "09",
+      "10",
+      "11",
+      "12",
+      "13",
+      "15",
+      "16",
+      "17",
+      "18",
+      "19",
+      "20",
+      "21",
+      "22",
+      "23",
+      "24",
+      "25",
+      "26",
+      "27",
+      "28",
+      "29",
+      "30",
+      "31",
+      "32",
+      "33",
+      "34",
+      "35",
+      "36",
+      "37",
+      "38",
+      "39",
+      "40",
+      "41",
+      "42",
+      "44",
+      "45",
+      "46",
+      "47",
+      "48",
+      "49",
+      "50",
+      "51",
+      "53",
+      "54",
+      "55",
+      "56",
+      "72"
+    )
+  )
+  expect_equal(
+    unique(all$target),
+    c(
       "wk inc flu hosp",
       "wk flu hosp rate category",
       "wk flu hosp rate"
@@ -63,15 +125,23 @@ test_that("connect_target_oracle_output on single file works on local hub", {
   expect_equal(
     sapply(all, class),
     c(
-      location = "character", target_end_date = "Date", target = "character",
-      output_type = "character", output_type_id = "character", oracle_value = "numeric"
+      location = "character",
+      target_end_date = "Date",
+      target = "character",
+      output_type = "character",
+      output_type_id = "character",
+      oracle_value = "numeric"
     )
   )
   expect_equal(
     sapply(all, typeof),
     c(
-      location = "character", target_end_date = "double", target = "character",
-      output_type = "character", output_type_id = "character", oracle_value = "double"
+      location = "character",
+      target_end_date = "double",
+      target = "character",
+      output_type = "character",
+      output_type_id = "character",
+      oracle_value = "double"
     )
   )
 
@@ -84,8 +154,11 @@ test_that("connect_target_oracle_output on single file works on local hub", {
   expect_equal(
     names(filter_date),
     c(
-      "location", "target_end_date",
-      "target", "output_type", "output_type_id",
+      "location",
+      "target_end_date",
+      "target",
+      "output_type",
+      "output_type_id",
       "oracle_value"
     )
   )
@@ -97,15 +170,64 @@ test_that("connect_target_oracle_output on single file works on local hub", {
   expect_equal(
     unique(filter_date$location),
     c(
-      "US", "01", "02", "04", "05", "06", "08", "09", "10", "11",
-      "12", "13", "15", "16", "17", "18", "19", "20", "21", "22", "23",
-      "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34",
-      "35", "36", "37", "38", "39", "40", "41", "42", "44", "45", "46",
-      "47", "48", "49", "50", "51", "53", "54", "55", "56", "72"
+      "US",
+      "01",
+      "02",
+      "04",
+      "05",
+      "06",
+      "08",
+      "09",
+      "10",
+      "11",
+      "12",
+      "13",
+      "15",
+      "16",
+      "17",
+      "18",
+      "19",
+      "20",
+      "21",
+      "22",
+      "23",
+      "24",
+      "25",
+      "26",
+      "27",
+      "28",
+      "29",
+      "30",
+      "31",
+      "32",
+      "33",
+      "34",
+      "35",
+      "36",
+      "37",
+      "38",
+      "39",
+      "40",
+      "41",
+      "42",
+      "44",
+      "45",
+      "46",
+      "47",
+      "48",
+      "49",
+      "50",
+      "51",
+      "53",
+      "54",
+      "55",
+      "56",
+      "72"
     )
   )
   expect_equal(
-    unique(filter_date$target), c(
+    unique(filter_date$target),
+    c(
       "wk inc flu hosp",
       "wk flu hosp rate category",
       "wk flu hosp rate"
@@ -115,18 +237,25 @@ test_that("connect_target_oracle_output on single file works on local hub", {
   expect_equal(
     sapply(filter_date, class),
     c(
-      location = "character", target_end_date = "Date", target = "character",
-      output_type = "character", output_type_id = "character", oracle_value = "numeric"
+      location = "character",
+      target_end_date = "Date",
+      target = "character",
+      output_type = "character",
+      output_type_id = "character",
+      oracle_value = "numeric"
     )
   )
   expect_equal(
     sapply(filter_date, typeof),
     c(
-      location = "character", target_end_date = "double", target = "character",
-      output_type = "character", output_type_id = "character", oracle_value = "double"
+      location = "character",
+      target_end_date = "double",
+      target = "character",
+      output_type = "character",
+      output_type_id = "character",
+      oracle_value = "double"
     )
   )
-
 
   # Filter for a specific location before collecting
   filter_location <- dplyr::filter(oo_con, location == "US") |>
@@ -137,13 +266,19 @@ test_that("connect_target_oracle_output on single file works on local hub", {
   expect_equal(
     names(filter_location),
     c(
-      "location", "target_end_date", "target", "output_type",
-      "output_type_id", "oracle_value"
+      "location",
+      "target_end_date",
+      "target",
+      "output_type",
+      "output_type_id",
+      "oracle_value"
     )
   )
   expect_equal(unique(filter_location$location), "US")
   expect_true(
-    filter_location[filter_location$output_type_id == "quantile", ]$output_type_id |>
+    filter_location[
+      filter_location$output_type_id == "quantile",
+    ]$output_type_id |>
       is.na() |>
       all()
   )
@@ -151,15 +286,23 @@ test_that("connect_target_oracle_output on single file works on local hub", {
   expect_equal(
     sapply(filter_location, class),
     c(
-      location = "character", target_end_date = "Date", target = "character",
-      output_type = "character", output_type_id = "character", oracle_value = "numeric"
+      location = "character",
+      target_end_date = "Date",
+      target = "character",
+      output_type = "character",
+      output_type_id = "character",
+      oracle_value = "numeric"
     )
   )
   expect_equal(
     sapply(filter_location, typeof),
     c(
-      location = "character", target_end_date = "double", target = "character",
-      output_type = "character", output_type_id = "character", oracle_value = "double"
+      location = "character",
+      target_end_date = "double",
+      target = "character",
+      output_type = "character",
+      output_type_id = "character",
+      oracle_value = "double"
     )
   )
 })
@@ -180,14 +323,16 @@ test_that("connect_target_oracle_output fails correctly", {
   oo_dir <- fs::path(oo_dir_hub_path, "target-data", "oracle-output")
 
   fs::dir_create(oo_dir)
-  split(oo_dat, oo_dat$target) |> purrr::iwalk(
-    ~ {
-      target <- gsub(" ", "_", .y)
-      path <- file.path(oo_dir, paste0("target-", target, ".csv"))
-      arrow::write_csv_arrow(.x, file = path)
-    }
-  )
-  expect_error(connect_target_oracle_output(oo_dir_hub_path),
+  split(oo_dat, oo_dat$target) |>
+    purrr::iwalk(
+      ~ {
+        target <- gsub(" ", "_", .y)
+        path <- file.path(oo_dir, paste0("target-", target, ".csv"))
+        arrow::write_csv_arrow(.x, file = path)
+      }
+    )
+  expect_error(
+    connect_target_oracle_output(oo_dir_hub_path),
     regexp = "Multiple .*oracle-output.* data found in hub .*oracle-output.csv"
   )
 
@@ -198,25 +343,28 @@ test_that("connect_target_oracle_output fails correctly", {
   fs::file_delete(oo_path)
 
   # Create two target oracle-output files with diffent formats
-  split(oo_dat, oo_dat$target) |> purrr::iwalk(
-    ~ {
-      target <- gsub(" ", "_", .y)
-      ext <- if (target == "wk_flu_hosp_rate") "csv" else "parquet"
-      path <- fs::path(oo_dir, paste0("target-", target), ext = ext)
-      if (ext == "parquet") {
-        arrow::write_parquet(.x, path)
-      } else {
-        arrow::write_csv_arrow(.x, file = path)
+  split(oo_dat, oo_dat$target) |>
+    purrr::iwalk(
+      ~ {
+        target <- gsub(" ", "_", .y)
+        ext <- if (target == "wk_flu_hosp_rate") "csv" else "parquet"
+        path <- fs::path(oo_dir, paste0("target-", target), ext = ext)
+        if (ext == "parquet") {
+          arrow::write_parquet(.x, path)
+        } else {
+          arrow::write_csv_arrow(.x, file = path)
+        }
       }
-    }
-  )
-  expect_error(connect_target_oracle_output(oo_dir_hub_path),
+    )
+  expect_error(
+    connect_target_oracle_output(oo_dir_hub_path),
     regexp = "Multiple data file formats .*csv.* and .*parquet"
   )
 
   # TEST when no oracle-output data found in target-data directory ================
   fs::dir_delete(oo_dir)
-  expect_error(connect_target_oracle_output(oo_dir_hub_path),
+  expect_error(
+    connect_target_oracle_output(oo_dir_hub_path),
     regexp = "No .*oracle-output.* data found in .*target-data.* directory"
   )
 })
@@ -234,20 +382,25 @@ test_that("connect_target_oracle_output on multiple non-partitioned files works 
   # Create a seperate file for each target in a oracle-output directory
   oo_dir <- fs::path(oo_dir_hub_path, "target-data", "oracle-output")
   fs::dir_create(oo_dir)
-  split(oo_dat, oo_dat$target) |> purrr::iwalk(
-    ~ {
-      target <- gsub(" ", "_", .y)
-      path <- file.path(oo_dir, paste0("target-", target, ".csv"))
-      arrow::write_csv_arrow(.x, file = path)
-    }
-  )
+  split(oo_dat, oo_dat$target) |>
+    purrr::iwalk(
+      ~ {
+        target <- gsub(" ", "_", .y)
+        path <- file.path(oo_dir, paste0("target-", target, ".csv"))
+        arrow::write_csv_arrow(.x, file = path)
+      }
+    )
 
   # TESTS ====
   # Connect to oracle-output data
   oo_con <- connect_target_oracle_output(oo_dir_hub_path)
-  expect_s3_class(oo_con,
+  expect_s3_class(
+    oo_con,
     c(
-      "target_oracle_output", "FileSystemDataset", "Dataset", "ArrowObject",
+      "target_oracle_output",
+      "FileSystemDataset",
+      "Dataset",
+      "ArrowObject",
       "R6"
     ),
     exact = TRUE
@@ -274,20 +427,81 @@ test_that("connect_target_oracle_output on multiple non-partitioned files works 
 
   expect_equal(dim(all), c(200340L, 6L))
   expect_s3_class(all, "tbl_df", exact = FALSE)
-  expect_equal(names(all), c("location", "target_end_date", "target", "output_type", "output_type_id", "oracle_value"))
-  expect_true(all[all$output_type_id == "quantile", ]$output_type_id |> is.na() |> all())
+  expect_equal(
+    names(all),
+    c(
+      "location",
+      "target_end_date",
+      "target",
+      "output_type",
+      "output_type_id",
+      "oracle_value"
+    )
+  )
+  expect_true(
+    all[all$output_type_id == "quantile", ]$output_type_id |> is.na() |> all()
+  )
   expect_equal(
     unique(all$location),
     c(
-      "US", "01", "02", "04", "05", "06", "08", "09", "10", "11",
-      "12", "13", "15", "16", "17", "18", "19", "20", "21", "22", "23",
-      "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34",
-      "35", "36", "37", "38", "39", "40", "41", "42", "44", "45", "46",
-      "47", "48", "49", "50", "51", "53", "54", "55", "56", "72"
+      "US",
+      "01",
+      "02",
+      "04",
+      "05",
+      "06",
+      "08",
+      "09",
+      "10",
+      "11",
+      "12",
+      "13",
+      "15",
+      "16",
+      "17",
+      "18",
+      "19",
+      "20",
+      "21",
+      "22",
+      "23",
+      "24",
+      "25",
+      "26",
+      "27",
+      "28",
+      "29",
+      "30",
+      "31",
+      "32",
+      "33",
+      "34",
+      "35",
+      "36",
+      "37",
+      "38",
+      "39",
+      "40",
+      "41",
+      "42",
+      "44",
+      "45",
+      "46",
+      "47",
+      "48",
+      "49",
+      "50",
+      "51",
+      "53",
+      "54",
+      "55",
+      "56",
+      "72"
     )
   )
   expect_equal(
-    unique(all$target), c(
+    unique(all$target),
+    c(
       "wk flu hosp rate",
       "wk flu hosp rate category",
       "wk inc flu hosp"
@@ -296,15 +510,23 @@ test_that("connect_target_oracle_output on multiple non-partitioned files works 
   expect_equal(
     sapply(all, class),
     c(
-      location = "character", target_end_date = "Date", target = "character",
-      output_type = "character", output_type_id = "character", oracle_value = "numeric"
+      location = "character",
+      target_end_date = "Date",
+      target = "character",
+      output_type = "character",
+      output_type_id = "character",
+      oracle_value = "numeric"
     )
   )
   expect_equal(
     sapply(all, typeof),
     c(
-      location = "character", target_end_date = "double", target = "character",
-      output_type = "character", output_type_id = "character", oracle_value = "double"
+      location = "character",
+      target_end_date = "double",
+      target = "character",
+      output_type = "character",
+      output_type_id = "character",
+      oracle_value = "double"
     )
   )
 
@@ -317,8 +539,12 @@ test_that("connect_target_oracle_output on multiple non-partitioned files works 
   expect_equal(
     names(filter_obs),
     c(
-      "location", "target_end_date", "target", "output_type",
-      "output_type_id", "oracle_value"
+      "location",
+      "target_end_date",
+      "target",
+      "output_type",
+      "output_type_id",
+      "oracle_value"
     )
   )
   expect_true(all(filter_obs$oracle_value < 1L))
@@ -330,15 +556,23 @@ test_that("connect_target_oracle_output on multiple non-partitioned files works 
   expect_equal(
     sapply(filter_obs, class),
     c(
-      location = "character", target_end_date = "Date", target = "character",
-      output_type = "character", output_type_id = "character", oracle_value = "numeric"
+      location = "character",
+      target_end_date = "Date",
+      target = "character",
+      output_type = "character",
+      output_type_id = "character",
+      oracle_value = "numeric"
     )
   )
   expect_equal(
     sapply(filter_obs, typeof),
     c(
-      location = "character", target_end_date = "double", target = "character",
-      output_type = "character", output_type_id = "character", oracle_value = "double"
+      location = "character",
+      target_end_date = "double",
+      target = "character",
+      output_type = "character",
+      output_type_id = "character",
+      oracle_value = "double"
     )
   )
 
@@ -365,17 +599,18 @@ test_that("connect_target_oracle_output works on local multi-file oracle_output 
   oo_dir <- fs::path(oo_dir_hub_path, "target-data", "oracle-output")
   fs::dir_create(oo_dir)
 
-  split(oo_dat, oo_dat$target) |> purrr::iwalk(
-    ~ {
-      target <- gsub(" ", "_", .y)
-      # Create subdirecties within `oracle-output` directory that do not contain
-      # data in the directory names, i.e. the data files within them contain all
-      # columns
-      fs::dir_create(file.path(oo_dir, target))
-      path <- file.path(oo_dir, target, paste0("target-", target, ".csv"))
-      arrow::write_csv_arrow(.x, file = path)
-    }
-  )
+  split(oo_dat, oo_dat$target) |>
+    purrr::iwalk(
+      ~ {
+        target <- gsub(" ", "_", .y)
+        # Create subdirecties within `oracle-output` directory that do not contain
+        # data in the directory names, i.e. the data files within them contain all
+        # columns
+        fs::dir_create(file.path(oo_dir, target))
+        path <- file.path(oo_dir, target, paste0("target-", target, ".csv"))
+        arrow::write_csv_arrow(.x, file = path)
+      }
+    )
   expect_equal(
     fs::dir_ls(oo_dir, recurse = TRUE, type = "file") |>
       fs::path_rel(oo_dir_hub_path) |>
@@ -387,9 +622,13 @@ test_that("connect_target_oracle_output works on local multi-file oracle_output 
     )
   )
   oo_con <- connect_target_oracle_output(oo_dir_hub_path)
-  expect_s3_class(oo_con,
+  expect_s3_class(
+    oo_con,
     c(
-      "target_oracle_output", "FileSystemDataset", "Dataset", "ArrowObject",
+      "target_oracle_output",
+      "FileSystemDataset",
+      "Dataset",
+      "ArrowObject",
       "R6"
     ),
     exact = TRUE
@@ -416,20 +655,40 @@ test_that("connect_target_oracle_output works on local multi-file oracle_output 
 
   expect_equal(dim(all), c(200340L, 6L))
   expect_s3_class(all, "tbl_df", exact = FALSE)
-  expect_true(all[all$output_type_id == "quantile", ]$output_type_id |> is.na() |> all())
-  expect_equal(names(all), c("location", "target_end_date", "target", "output_type", "output_type_id", "oracle_value"))
+  expect_true(
+    all[all$output_type_id == "quantile", ]$output_type_id |> is.na() |> all()
+  )
+  expect_equal(
+    names(all),
+    c(
+      "location",
+      "target_end_date",
+      "target",
+      "output_type",
+      "output_type_id",
+      "oracle_value"
+    )
+  )
   expect_equal(
     sapply(all, typeof),
     c(
-      location = "character", target_end_date = "double", target = "character",
-      output_type = "character", output_type_id = "character", oracle_value = "double"
+      location = "character",
+      target_end_date = "double",
+      target = "character",
+      output_type = "character",
+      output_type_id = "character",
+      oracle_value = "double"
     )
   )
   expect_equal(
     sapply(all, class),
     c(
-      location = "character", target_end_date = "Date", target = "character",
-      output_type = "character", output_type_id = "character", oracle_value = "numeric"
+      location = "character",
+      target_end_date = "Date",
+      target = "character",
+      output_type = "character",
+      output_type_id = "character",
+      oracle_value = "numeric"
     )
   )
 
@@ -456,7 +715,12 @@ test_that("connect_target_oracle_output with HIVE-PARTTIONED data works on local
   oo_dir <- fs::path(oo_dir_hub_path, "target-data", "oracle-output")
   fs::dir_create(oo_dir)
 
-  arrow::write_dataset(oo_dat, oo_dir, partitioning = "target", format = "parquet")
+  arrow::write_dataset(
+    oo_dat,
+    oo_dir,
+    partitioning = "target",
+    format = "parquet"
+  )
   expect_equal(
     fs::dir_ls(oo_dir, recurse = TRUE, type = "file") |>
       fs::path_rel(oo_dir_hub_path) |>
@@ -468,9 +732,13 @@ test_that("connect_target_oracle_output with HIVE-PARTTIONED data works on local
     )
   )
   oo_con <- connect_target_oracle_output(oo_dir_hub_path)
-  expect_s3_class(oo_con,
+  expect_s3_class(
+    oo_con,
     c(
-      "target_oracle_output", "FileSystemDataset", "Dataset", "ArrowObject",
+      "target_oracle_output",
+      "FileSystemDataset",
+      "Dataset",
+      "ArrowObject",
       "R6"
     ),
     exact = TRUE
@@ -496,23 +764,40 @@ test_that("connect_target_oracle_output with HIVE-PARTTIONED data works on local
 
   expect_equal(dim(all), c(200340L, 6L))
   expect_s3_class(all, "tbl_df", exact = FALSE)
-  expect_true(all[all$output_type_id == "quantile", ]$output_type_id |> is.na() |> all())
-  expect_equal(names(all), c(
-    "location", "target_end_date", "output_type", "output_type_id",
-    "oracle_value", "target"
-  ))
+  expect_true(
+    all[all$output_type_id == "quantile", ]$output_type_id |> is.na() |> all()
+  )
+  expect_equal(
+    names(all),
+    c(
+      "location",
+      "target_end_date",
+      "output_type",
+      "output_type_id",
+      "oracle_value",
+      "target"
+    )
+  )
   expect_equal(
     sapply(all, class),
     c(
-      location = "character", target_end_date = "Date", output_type = "character",
-      output_type_id = "character", oracle_value = "numeric", target = "character"
+      location = "character",
+      target_end_date = "Date",
+      output_type = "character",
+      output_type_id = "character",
+      oracle_value = "numeric",
+      target = "character"
     )
   )
   expect_equal(
     sapply(all, typeof),
     c(
-      location = "character", target_end_date = "double", output_type = "character",
-      output_type_id = "character", oracle_value = "double", target = "character"
+      location = "character",
+      target_end_date = "double",
+      output_type = "character",
+      output_type_id = "character",
+      oracle_value = "double",
+      target = "character"
     )
   )
 
@@ -540,90 +825,104 @@ test_that("connect_target_oracle_output with HIVE-PARTTIONED data works on local
 })
 
 
-test_that(
-  "connect_target_oracle_output works on single-file S3 SubTreeFileSystem hub",
-  {
-    skip_if_offline()
-    hub_path <- s3_bucket("example-complex-forecast-hub")
-    oo_con <- connect_target_oracle_output(hub_path)
+test_that("connect_target_oracle_output works on single-file S3 SubTreeFileSystem hub", {
+  skip_if_offline()
+  hub_path <- s3_bucket("example-complex-forecast-hub")
+  oo_con <- connect_target_oracle_output(hub_path)
 
-    expect_s3_class(oo_con,
-      c(
-        "target_oracle_output", "FileSystemDataset", "Dataset", "ArrowObject",
-        "R6"
-      ),
-      exact = TRUE
-    )
+  expect_s3_class(
+    oo_con,
+    c(
+      "target_oracle_output",
+      "FileSystemDataset",
+      "Dataset",
+      "ArrowObject",
+      "R6"
+    ),
+    exact = TRUE
+  )
 
-    # Check files opened correctly as oo_path captured correctly
-    expect_equal(
-      basename(attr(oo_con, "oo_path")),
-      "oracle-output.csv"
-    )
-    expect_equal(
-      attr(oo_con, "hub_path"),
-      "s3://example-complex-forecast-hub"
-    )
-    expect_length(oo_con$files, 1L)
+  # Check files opened correctly as oo_path captured correctly
+  expect_equal(
+    basename(attr(oo_con, "oo_path")),
+    "oracle-output.csv"
+  )
+  expect_equal(
+    attr(oo_con, "hub_path"),
+    "s3://example-complex-forecast-hub"
+  )
+  expect_length(oo_con$files, 1L)
 
-    expect_equal(
-      oo_con$schema$ToString(),
-      "location: string\ntarget_end_date: date32[day]\ntarget: string\noutput_type: string\noutput_type_id: string\noracle_value: double" # nolint: line_length_linter
-    )
-    # Test the collect method
-    all <- dplyr::collect(oo_con)
+  expect_equal(
+    oo_con$schema$ToString(),
+    "location: string\ntarget_end_date: date32[day]\ntarget: string\noutput_type: string\noutput_type_id: string\noracle_value: double" # nolint: line_length_linter
+  )
+  # Test the collect method
+  all <- dplyr::collect(oo_con)
 
-    expect_equal(dim(all), c(200340L, 6L))
-    expect_s3_class(all, "tbl_df", exact = FALSE)
-    expect_equal(
-      names(all),
-      c(
-        "location", "target_end_date", "target", "output_type",
-        "output_type_id", "oracle_value"
-      )
+  expect_equal(dim(all), c(200340L, 6L))
+  expect_s3_class(all, "tbl_df", exact = FALSE)
+  expect_equal(
+    names(all),
+    c(
+      "location",
+      "target_end_date",
+      "target",
+      "output_type",
+      "output_type_id",
+      "oracle_value"
     )
-    expect_true(all[all$output_type_id == "quantile", ]$output_type_id |> is.na() |> all())
-    expect_equal(
-      sapply(all, class),
-      c(
-        location = "character", target_end_date = "Date", target = "character",
-        output_type = "character", output_type_id = "character", oracle_value = "numeric"
-      )
+  )
+  expect_true(
+    all[all$output_type_id == "quantile", ]$output_type_id |> is.na() |> all()
+  )
+  expect_equal(
+    sapply(all, class),
+    c(
+      location = "character",
+      target_end_date = "Date",
+      target = "character",
+      output_type = "character",
+      output_type_id = "character",
+      oracle_value = "numeric"
     )
-    expect_equal(
-      sapply(all, typeof),
-      c(
-        location = "character", target_end_date = "double", target = "character",
-        output_type = "character", output_type_id = "character", oracle_value = "double"
-      )
+  )
+  expect_equal(
+    sapply(all, typeof),
+    c(
+      location = "character",
+      target_end_date = "double",
+      target = "character",
+      output_type = "character",
+      output_type_id = "character",
+      oracle_value = "double"
     )
-  }
-)
+  )
+})
 
-test_that(
-  "connect_target_oracle_output works with multi-file SubTreeFileSystem hub",
-  {
-    skip_if_offline()
-    skip_on_os("windows")
-    # Skipping the test on windows because the use of lower level
-    # SubTreeFileSystem$create() function on windows is throwing unrelated errors
-    # related to local paths on windows which are not guaranteed to work:
-    # (see https://arrow.apache.org/docs/cpp/api/filesystem.html#subtree-filesystem-wrapper)
-    # We've already shown these tests work on linux and macos and on actual s3 cloud hubs
-    # with single files.
+test_that("connect_target_oracle_output works with multi-file SubTreeFileSystem hub", {
+  skip_if_offline()
+  skip_on_os("windows")
+  # Skipping the test on windows because the use of lower level
+  # SubTreeFileSystem$create() function on windows is throwing unrelated errors
+  # related to local paths on windows which are not guaranteed to work:
+  # (see https://arrow.apache.org/docs/cpp/api/filesystem.html#subtree-filesystem-wrapper)
+  # We've already shown these tests work on linux and macos and on actual s3 cloud hubs
+  # with single files.
 
-    fs::dir_delete(oo_dir_hub_path)
-    fs::dir_copy(oo_hub_path, oo_dir_hub_path)
-    oo_path <- validate_target_data_path(oo_dir_hub_path, "oracle-output")
-    # Read oracle_output data from single file
-    oo_dat <- arrow::read_csv_arrow(oo_path)
-    # Delete single oracle-output file in preparation for creating oracle-output directory
-    fs::file_delete(oo_path)
+  fs::dir_delete(oo_dir_hub_path)
+  fs::dir_copy(oo_hub_path, oo_dir_hub_path)
+  oo_path <- validate_target_data_path(oo_dir_hub_path, "oracle-output")
+  # Read oracle_output data from single file
+  oo_dat <- arrow::read_csv_arrow(oo_path)
+  # Delete single oracle-output file in preparation for creating oracle-output directory
+  fs::file_delete(oo_path)
 
-    # Create a separate file for each target in a oracle-output directory
-    oo_dir <- fs::path(oo_dir_hub_path, "target-data", "oracle-output")
-    fs::dir_create(oo_dir)
-    split(oo_dat, oo_dat$target) |> purrr::iwalk(
+  # Create a separate file for each target in a oracle-output directory
+  oo_dir <- fs::path(oo_dir_hub_path, "target-data", "oracle-output")
+  fs::dir_create(oo_dir)
+  split(oo_dat, oo_dat$target) |>
+    purrr::iwalk(
       ~ {
         target <- gsub(" ", "_", .y)
         path <- file.path(oo_dir, paste0("target-", target, ".csv"))
@@ -631,148 +930,223 @@ test_that(
       }
     )
 
-    hub_path <- withr::local_tempdir()
-    # Create a SubTreeFileSystem hub to mimic cloud hub and copy example hub contents
-    # into it
-    loc_fs <- arrow::SubTreeFileSystem$create(hub_path)
-    arrow::copy_files(oo_dir_hub_path, loc_fs)
-    config_tasks <- read_config(hub_path)
+  hub_path <- withr::local_tempdir()
+  # Create a SubTreeFileSystem hub to mimic cloud hub and copy example hub contents
+  # into it
+  loc_fs <- arrow::SubTreeFileSystem$create(hub_path)
+  arrow::copy_files(oo_dir_hub_path, loc_fs)
+  config_tasks <- read_config(hub_path)
 
-    # mock read_config function as it assumes any SubTreeFileSystem hub is an s3 bucket
-    # and creates `s3` prefixed paths to URIs.
-    local_mocked_bindings(
-      read_config = function(...) {
-        config_tasks
-      }
-    )
+  # mock read_config function as it assumes any SubTreeFileSystem hub is an s3 bucket
+  # and creates `s3` prefixed paths to URIs.
+  local_mocked_bindings(
+    read_config = function(...) {
+      config_tasks
+    }
+  )
 
-    # TESTS ====
-    # Connect to oracle-output data
-    oo_con <- connect_target_oracle_output(loc_fs)
-    expect_s3_class(oo_con,
-      c(
-        "target_oracle_output", "FileSystemDataset", "Dataset", "ArrowObject",
-        "R6"
-      ),
-      exact = TRUE
-    )
+  # TESTS ====
+  # Connect to oracle-output data
+  oo_con <- connect_target_oracle_output(loc_fs)
+  expect_s3_class(
+    oo_con,
+    c(
+      "target_oracle_output",
+      "FileSystemDataset",
+      "Dataset",
+      "ArrowObject",
+      "R6"
+    ),
+    exact = TRUE
+  )
 
-    # Check files opened correctly as oo_path captured correctly
-    expect_equal(
-      basename(attr(oo_con, "oo_path")),
-      "oracle-output"
-    )
-    expect_length(oo_con$files, 3L)
-    expect_equal(
-      basename(oo_con$files),
-      basename(fs::dir_ls(oo_dir, recurse = TRUE, type = "file"))
-    )
+  # Check files opened correctly as oo_path captured correctly
+  expect_equal(
+    basename(attr(oo_con, "oo_path")),
+    "oracle-output"
+  )
+  expect_length(oo_con$files, 3L)
+  expect_equal(
+    basename(oo_con$files),
+    basename(fs::dir_ls(oo_dir, recurse = TRUE, type = "file"))
+  )
 
-    expect_equal(
-      oo_con$schema$ToString(),
-      "location: string\ntarget_end_date: date32[day]\ntarget: string\noutput_type: string\noutput_type_id: string\noracle_value: double" # nolint: line_length_linter
-    )
+  expect_equal(
+    oo_con$schema$ToString(),
+    "location: string\ntarget_end_date: date32[day]\ntarget: string\noutput_type: string\noutput_type_id: string\noracle_value: double" # nolint: line_length_linter
+  )
 
-    # Test the collect method
-    all <- dplyr::collect(oo_con)
+  # Test the collect method
+  all <- dplyr::collect(oo_con)
 
-    expect_equal(dim(all), c(200340L, 6L))
-    expect_s3_class(all, "tbl_df", exact = FALSE)
-    expect_equal(
-      names(all),
-      c(
-        "location", "target_end_date", "target", "output_type",
-        "output_type_id", "oracle_value"
-      )
-    )
-    expect_true(
-      all[all$output_type_id == "quantile", ]$output_type_id |>
-        is.na() |>
-        all()
-    )
-    expect_setequal(
-      unique(all$location),
-      c(
-        "01", "15", "18", "27", "30", "37", "48", "US", "32", "20",
-        "17", "29", "41", "04", "06", "13", "19", "21", "22", "24", "23",
-        "26", "28", "38", "31", "34", "39", "40", "42", "72", "45", "51",
-        "53", "55", "54", "56", "44", "05", "12", "16", "35", "36", "47",
-        "02", "09", "50", "08", "11", "10", "25", "33", "46", "49"
-      )
-    )
-    expect_setequal(
-      unique(all$target), c("wk inc flu hosp", "wk flu hosp rate category", "wk flu hosp rate")
-    )
-    expect_equal(
-      sapply(all, class),
-      c(
-        location = "character", target_end_date = "Date", target = "character",
-        output_type = "character", output_type_id = "character", oracle_value = "numeric"
-      )
-    )
-    expect_equal(
-      sapply(all, typeof),
-      c(
-        location = "character", target_end_date = "double", target = "character",
-        output_type = "character", output_type_id = "character", oracle_value = "double"
-      )
-    )
-
-    # Filter for a specific date before collecting
-    filter_obs <- dplyr::filter(oo_con, oracle_value < 1L) |>
-      dplyr::collect()
-
-    expect_equal(dim(filter_obs), c(19535L, 6L))
-    expect_s3_class(filter_obs, "tbl_df", exact = FALSE)
-    expect_equal(names(filter_obs), c(
-      "location", "target_end_date",
-      "target", "output_type", "output_type_id",
+  expect_equal(dim(all), c(200340L, 6L))
+  expect_s3_class(all, "tbl_df", exact = FALSE)
+  expect_equal(
+    names(all),
+    c(
+      "location",
+      "target_end_date",
+      "target",
+      "output_type",
+      "output_type_id",
       "oracle_value"
-    ))
-    expect_true(all(filter_obs$oracle_value < 1L))
-    expect_equal(
-      sapply(filter_obs, class),
-      c(
-        location = "character", target_end_date = "Date", target = "character",
-        output_type = "character", output_type_id = "character", oracle_value = "numeric"
-      )
     )
-    expect_equal(
-      sapply(filter_obs, typeof),
-      c(
-        location = "character", target_end_date = "double", target = "character",
-        output_type = "character", output_type_id = "character", oracle_value = "double"
-      )
+  )
+  expect_true(
+    all[all$output_type_id == "quantile", ]$output_type_id |>
+      is.na() |>
+      all()
+  )
+  expect_setequal(
+    unique(all$location),
+    c(
+      "01",
+      "15",
+      "18",
+      "27",
+      "30",
+      "37",
+      "48",
+      "US",
+      "32",
+      "20",
+      "17",
+      "29",
+      "41",
+      "04",
+      "06",
+      "13",
+      "19",
+      "21",
+      "22",
+      "24",
+      "23",
+      "26",
+      "28",
+      "38",
+      "31",
+      "34",
+      "39",
+      "40",
+      "42",
+      "72",
+      "45",
+      "51",
+      "53",
+      "55",
+      "54",
+      "56",
+      "44",
+      "05",
+      "12",
+      "16",
+      "35",
+      "36",
+      "47",
+      "02",
+      "09",
+      "50",
+      "08",
+      "11",
+      "10",
+      "25",
+      "33",
+      "46",
+      "49"
     )
-  }
-)
+  )
+  expect_setequal(
+    unique(all$target),
+    c("wk inc flu hosp", "wk flu hosp rate category", "wk flu hosp rate")
+  )
+  expect_equal(
+    sapply(all, class),
+    c(
+      location = "character",
+      target_end_date = "Date",
+      target = "character",
+      output_type = "character",
+      output_type_id = "character",
+      oracle_value = "numeric"
+    )
+  )
+  expect_equal(
+    sapply(all, typeof),
+    c(
+      location = "character",
+      target_end_date = "double",
+      target = "character",
+      output_type = "character",
+      output_type_id = "character",
+      oracle_value = "double"
+    )
+  )
 
-test_that(
-  'connect_target_timeseries parses "NA" and "" correctly',
-  {
-    skip_if_offline()
-    oo_na_hub_path <- fs::path(tmp_dir, "oo_na_file")
-    fs::dir_copy(oo_hub_path, oo_na_hub_path)
-    oo_path <- validate_target_data_path(oo_na_hub_path, "oracle-output")
-    # Read oracle_output data from single file
-    oo_dat <- arrow::read_csv_arrow(oo_path)
+  # Filter for a specific date before collecting
+  filter_obs <- dplyr::filter(oo_con, oracle_value < 1L) |>
+    dplyr::collect()
 
-    # Introduce character "NA" value
-    oo_dat$location[1] <- "NA"
-    # Write NAs out as blank strings (default in write_csv_arrow)
-    arrow::write_csv_arrow(oo_dat, oo_path)
+  expect_equal(dim(filter_obs), c(19535L, 6L))
+  expect_s3_class(filter_obs, "tbl_df", exact = FALSE)
+  expect_equal(
+    names(filter_obs),
+    c(
+      "location",
+      "target_end_date",
+      "target",
+      "output_type",
+      "output_type_id",
+      "oracle_value"
+    )
+  )
+  expect_true(all(filter_obs$oracle_value < 1L))
+  expect_equal(
+    sapply(filter_obs, class),
+    c(
+      location = "character",
+      target_end_date = "Date",
+      target = "character",
+      output_type = "character",
+      output_type_id = "character",
+      oracle_value = "numeric"
+    )
+  )
+  expect_equal(
+    sapply(filter_obs, typeof),
+    c(
+      location = "character",
+      target_end_date = "double",
+      target = "character",
+      output_type = "character",
+      output_type_id = "character",
+      oracle_value = "double"
+    )
+  )
+})
 
-    oo_con <- connect_target_oracle_output(oo_na_hub_path, na = "")
-    expect_equal(
-      oo_con$schema$ToString(),
-      "location: string\ntarget_end_date: date32[day]\ntarget: string\noutput_type: string\noutput_type_id: string\noracle_value: double" # nolint: line_length_linter
-    )
-    all <- dplyr::collect(oo_con)
-    expect_true(all$location[1] == "NA")
-    expect_true(
-      all[oo_dat$output_type_id == "", "output_type_id"] |>
-        is.na() |>
-        all()
-    )
-  }
-)
+test_that('connect_target_timeseries parses "NA" and "" correctly', {
+  skip_if_offline()
+  oo_na_hub_path <- fs::path(tmp_dir, "oo_na_file")
+  fs::dir_copy(oo_hub_path, oo_na_hub_path)
+  oo_path <- validate_target_data_path(oo_na_hub_path, "oracle-output")
+  # Read oracle_output data from single file
+  oo_dat <- arrow::read_csv_arrow(oo_path)
+
+  # Introduce character "NA" value
+  oo_dat$location[1] <- "NA"
+  # Write NAs out as blank strings (default in write_csv_arrow)
+  arrow::write_csv_arrow(oo_dat, oo_path)
+
+  oo_con <- connect_target_oracle_output(oo_na_hub_path, na = "")
+  expect_equal(
+    oo_con$schema$ToString(),
+    "location: string\ntarget_end_date: date32[day]\ntarget: string\noutput_type: string\noutput_type_id: string\noracle_value: double" # nolint: line_length_linter
+  )
+  all <- dplyr::collect(oo_con)
+  expect_true(all$location[1] == "NA")
+  expect_true(
+    all[oo_dat$output_type_id == "", "output_type_id"] |>
+      is.na() |>
+      all()
+  )
+})

--- a/tests/testthat/test-connect_target_oracle.R
+++ b/tests/testthat/test-connect_target_oracle.R
@@ -1150,3 +1150,15 @@ test_that('connect_target_timeseries parses "NA" and "" correctly', {
       all()
   )
 })
+
+test_that("connect_target_oracle_output output_type_id_datatype arg works", {
+  skip_if_offline()
+  oo_con <- connect_target_oracle_output(
+    oo_hub_path,
+    output_type_id_datatype = "double"
+  )
+  expect_equal(
+    oo_con$schema$ToString(),
+    "location: string\ntarget_end_date: date32[day]\ntarget: string\noutput_type: string\noutput_type_id: double\noracle_value: double" # nolint: line_length_linter
+  )
+})

--- a/tests/testthat/test-create_oracle_output_schema.R
+++ b/tests/testthat/test-create_oracle_output_schema.R
@@ -17,7 +17,12 @@ test_that("create_oracle_output_schema works", {
   oo_dir <- fs::path(tmp_hub_path, "target-data", "oracle-output")
   fs::dir_create(oo_dir)
   oo_dat <- arrow::read_csv_arrow(oo_path)
-  arrow::write_dataset(oo_dat, oo_dir, partitioning = "target_end_date", format = "parquet")
+  arrow::write_dataset(
+    oo_dat,
+    oo_dir,
+    partitioning = "target_end_date",
+    format = "parquet"
+  )
   fs::file_delete(oo_path)
 
   expect_equal(
@@ -27,21 +32,39 @@ test_that("create_oracle_output_schema works", {
 
   # Check that ignoring a partition folder returns the same schema
   expect_equal(
-    create_oracle_output_schema(tmp_hub_path, ignore_files = "target_end_date=2023-06-17")$ToString(),
+    create_oracle_output_schema(
+      tmp_hub_path,
+      ignore_files = "target_end_date=2023-06-17"
+    )$ToString(),
     "location: string\ntarget: string\noutput_type: string\noutput_type_id: string\noracle_value: double\ntarget_end_date: date32[day]" # nolint: line_length_linter
   )
 })
 
-test_that(
-  "create_oracle_output_schema works on single-file S3 SubTreeFileSystem hub",
-  {
-    skip_if_offline()
-    hub_path <- s3_bucket("example-complex-forecast-hub")
-    oo_schema <- create_oracle_output_schema(hub_path)
+test_that("create_oracle_output_schema works on single-file S3 SubTreeFileSystem hub", {
+  skip_if_offline()
+  hub_path <- s3_bucket("example-complex-forecast-hub")
+  oo_schema <- create_oracle_output_schema(hub_path)
 
-    expect_equal(
-      oo_schema$ToString(),
-      "location: string\ntarget_end_date: date32[day]\ntarget: string\noutput_type: string\noutput_type_id: string\noracle_value: double" # nolint: line_length_linter
+  expect_equal(
+    oo_schema$ToString(),
+    "location: string\ntarget_end_date: date32[day]\ntarget: string\noutput_type: string\noutput_type_id: string\noracle_value: double" # nolint: line_length_linter
+  )
+})
+
+test_that("create_oracle_output_schema returns r datatypes", {
+  skip_if_offline()
+  hub_path <- s3_bucket("example-complex-forecast-hub")
+  oo_schema <- create_oracle_output_schema(hub_path, r_schema = TRUE)
+
+  expect_equal(
+    oo_schema,
+    c(
+      location = "character",
+      target_end_date = "Date",
+      target = "character",
+      output_type = "character",
+      output_type_id = "character",
+      oracle_value = "double"
     )
-  }
-)
+  )
+})

--- a/tests/testthat/test-create_oracle_output_schema.R
+++ b/tests/testthat/test-create_oracle_output_schema.R
@@ -68,3 +68,17 @@ test_that("create_oracle_output_schema returns r datatypes", {
     )
   )
 })
+
+test_that("create_oracle_output_schema output_type_id override works", {
+  skip_if_offline()
+  hub_path <- s3_bucket("example-complex-forecast-hub")
+  oo_schema <- create_oracle_output_schema(
+    hub_path,
+    r_schema = TRUE,
+    output_type_id_datatype = "double"
+  )
+  expect_equal(
+    oo_schema[["output_type_id"]],
+    "double"
+  )
+})

--- a/tests/testthat/test-create_timeseries_schema.R
+++ b/tests/testthat/test-create_timeseries_schema.R
@@ -33,7 +33,12 @@ test_that("create_timeseries_schema works", {
   ts_dir <- fs::path(tmp_hub_path, "target-data", "time-series")
   fs::dir_create(ts_dir)
   ts_dat <- arrow::read_csv_arrow(ts_path)
-  arrow::write_dataset(ts_dat, ts_dir, partitioning = "date", format = "parquet")
+  arrow::write_dataset(
+    ts_dat,
+    ts_dir,
+    partitioning = "date",
+    format = "parquet"
+  )
   fs::file_delete(ts_path)
 
   expect_error(
@@ -51,7 +56,11 @@ test_that("create_timeseries_schema works", {
   fs::dir_create(ts_dir)
   ts_dat |>
     dplyr::rename(target_end_date = date) |>
-    arrow::write_dataset(ts_dir, partitioning = "target_end_date", format = "parquet")
+    arrow::write_dataset(
+      ts_dir,
+      partitioning = "target_end_date",
+      format = "parquet"
+    )
 
   expect_equal(
     create_timeseries_schema(tmp_hub_path)$ToString(),
@@ -60,21 +69,37 @@ test_that("create_timeseries_schema works", {
 
   # Check that ignoring a partition folder returns the same schema
   expect_equal(
-    create_timeseries_schema(tmp_hub_path, ignore_files = "target_end_date=2023-11-04")$ToString(),
+    create_timeseries_schema(
+      tmp_hub_path,
+      ignore_files = "target_end_date=2023-11-04"
+    )$ToString(),
     "target: string\nlocation: string\nobservation: double\nas_of: date32[day]\ntarget_end_date: date32[day]"
   )
 })
 
-test_that(
-  "create_timeseries_schema works on single-file S3 SubTreeFileSystem hub",
-  {
-    skip_if_offline()
-    hub_path <- s3_bucket("example-complex-forecast-hub")
-    ts_schema <- create_timeseries_schema(hub_path)
+test_that("create_timeseries_schema works on single-file S3 SubTreeFileSystem hub", {
+  skip_if_offline()
+  hub_path <- s3_bucket("example-complex-forecast-hub")
+  ts_schema <- create_timeseries_schema(hub_path)
 
-    expect_equal(
-      ts_schema$ToString(),
-      "date: date32[day]\ntarget: string\nlocation: string\nobservation: double"
+  expect_equal(
+    ts_schema$ToString(),
+    "date: date32[day]\ntarget: string\nlocation: string\nobservation: double"
+  )
+})
+
+test_that("create_timeseries_schema returns r datatypes", {
+  skip_if_offline()
+  hub_path <- s3_bucket("example-complex-forecast-hub")
+  ts_schema <- create_timeseries_schema(hub_path, r_schema = TRUE)
+
+  expect_equal(
+    ts_schema,
+    c(
+      date = "Date",
+      target = "character",
+      location = "character",
+      observation = "double"
     )
-  }
-)
+  )
+})


### PR DESCRIPTION
This PR resolves #95 by:

* Adding an `r_schema` argument to `create_timeseries_schema()` and `create_oracle_output_schema()` functions to enable returning the schema as a vector of R data types instead of an `arrow::Schema` object 
* Adding an `output_type_id_datatype` argument to `create_oracle_output_schema()` and `connect_target_oracle_output()` functions to allow users to explicitly specify the data type of the `output_type_id` column in the schema. This ensuring compatibility with `create_hub_schema()` and `connect_hub()`.

All files edited have also been restyled with air but I've tried to separate this styling into separate commits as much as possible so might be easier to review commit by commit (note that styling commits do not need reviewing).