### PR TITLE
Update NEWS.md with changes since v2.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # hubData (development version)
 
+## New features and improvements
+
+* Added `date_col` parameter to `create_oracle_output_schema()` and `connect_target_oracle_output()` to match time-series functionality (#121). In inference mode (when `target-data.json` is not present), users can now specify which column contains date information to ensure it's typed as `date32()`. The parameter is ignored in v6+ config mode where date columns are defined in the configuration.
+
+## Bug fixes and minor improvements
+
+* `create_timeseries_schema()` and `create_oracle_output_schema()` now issue a warning instead of an error when no date column is detected during schema inference (when `target-data.json` config is not present) (#119). This allows schema creation to succeed and enables validation tools to properly catch and report missing date columns with better error messages.
+
 # hubData 2.0.0
 
 ## Breaking changes


### PR DESCRIPTION
## Summary
Updates NEWS.md with user-facing changes that were merged since v2.0.0 release but not documented:

- Added `date_col` parameter to `create_oracle_output_schema()` and `connect_target_oracle_output()` (#121)
- Relaxed error to warning when no date column detected in inference mode (#119)

## Context
PRs #119-122 were merged without updating NEWS.md. This PR adds the missing documentation for user-facing changes.