### PR TITLE
Ensure `load_model_metadata()` does not produce multiple rows per model from array-valued top-level fields

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,7 @@ Suggests:
     knitr,
     mockery,
     rmarkdown,
-    testthat (>= 3.2.0),
+    testthat (>= 3.3.0),
     withr
 Remotes:
     hubverse-org/hubUtils,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,8 @@ Authors@R:
            comment = c(ORCID = "0000-0003-3503-9899")),
       person("Evan L.", "Ray", , "elray@umass.edu", role = "ctb"),
       person("Becky", "Sweger", , "bsweger@gmail.com", role = "ctb"),
+      person("Dylan H.", "Morris", "dylan@dylanhmorris.com", role = "ctb"),
+           comment = c(ORCID = "0000-0002-3655-406X")),
       person(family = "Consortium of Infectious Disease Modeling Hubs",
            role = c("cph")))
 Description: A set of utility functions for accessing and working with

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Authors@R:
            comment = c(ORCID = "0000-0003-3503-9899")),
       person("Evan L.", "Ray", , "elray@umass.edu", role = "ctb"),
       person("Becky", "Sweger", , "bsweger@gmail.com", role = "ctb"),
-      person("Dylan H.", "Morris", "dylan@dylanhmorris.com", role = "ctb"),
+      person("Dylan H.", "Morris", "dylan@dylanhmorris.com", role = "ctb",
            comment = c(ORCID = "0000-0002-3655-406X")),
       person(family = "Consortium of Infectious Disease Modeling Hubs",
            role = c("cph")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # hubData (development version)
 
+* Fixed bug `load_model_metadata()` that caused array-valued top-level fields in model metadata YAML files to parse incorrectly or fail to parse at all (#137). Array-valued top-level fields are now translated into list columns, per the function specification. **Note**: The bug also meant that length-1 top-level arrays parsed equivalently to top-level scalars, e.g. both `y: "x"` and `y: ["x"]` parsed as a character column `y` with value `x`. With the fix, those entries parse differently: `y: "x"` parses as a character column; `y: ["x"]` parses as a list column.
+
 # hubData 2.1.0
 
 ## New features and improvements

--- a/R/load_model_metadata.R
+++ b/R/load_model_metadata.R
@@ -57,9 +57,14 @@ load_model_metadata.default <- function(hub_path, model_ids = NULL) {
     cli::cli_abort(c("x" = "{.path model-metadata} directory is empty."))
   }
 
-  meta_l <- purrr::map(
-    metadata_paths,
-    ~ yaml::read_yaml(.x) |>
+  meta_l <- purrr::map(metadata_paths,
+    # Use a custom handler to ensure that length-1 arrays become lists rather
+    # than scalars, and can be row-bound to non-length 1 arrays if those exist
+    # in other model-metadata files. See
+    # https://github.com/r-lib/yaml/issues/69                   
+    ~ yaml::read_yaml(.x,
+                      handlers = list(seq = function(x) x),
+                      as.named.list=TRUE) |>
       # Here we add depth to list elements so when the top level is unlisted at
       # the `bind_rows` step below, they do not create a row per list element.
       # Instead the expected single row per model is created.

--- a/R/load_model_metadata.R
+++ b/R/load_model_metadata.R
@@ -57,14 +57,17 @@ load_model_metadata.default <- function(hub_path, model_ids = NULL) {
     cli::cli_abort(c("x" = "{.path model-metadata} directory is empty."))
   }
 
-  meta_l <- purrr::map(metadata_paths,
+  meta_l <- purrr::map(
+    metadata_paths,
     # Use a custom handler to ensure that length-1 arrays become lists rather
     # than scalars, and can be row-bound to non-length 1 arrays if those exist
     # in other model-metadata files. See
-    # https://github.com/r-lib/yaml/issues/69                   
-    ~ yaml::read_yaml(.x,
-                      handlers = list(seq = function(x) x),
-                      as.named.list=TRUE) |>
+    # https://github.com/r-lib/yaml/issues/69
+    ~ yaml::read_yaml(
+      .x,
+      handlers = list(seq = function(x) x),
+      as.named.list = TRUE
+    ) |>
       # Here we add depth to list elements so when the top level is unlisted at
       # the `bind_rows` step below, they do not create a row per list element.
       # Instead the expected single row per model is created.

--- a/tests/testthat/_snaps/load_model_metadata.md
+++ b/tests/testthat/_snaps/load_model_metadata.md
@@ -183,3 +183,90 @@
         .. ..$ data_inputs: chr "description of the data imputs"
        $ ensemble_of_hub_models: logi [1:2] FALSE FALSE
 
+# Top-level array fields yield list columns, even if they are absent or length-1
+
+    Code
+      str(model_metadata)
+    Output
+      tibble [4 x 24] (S3: tbl_df/tbl/data.frame)
+       $ model_id                       : chr [1:4] "multi-entry" "no-entry" "single-entry" "two-arrays"
+       $ team_abbr                      : chr [1:4] "multi" "no" "single" "two"
+       $ model_abbr                     : chr [1:4] "entry" "entry" "entry" "arrays"
+       $ team_name                      : chr [1:4] "Hub Coordination Team" "Hub Coordination Team" "Hub Coordination Team" "Hub Coordination Team"
+       $ model_name                     : chr [1:4] "Multi entry" "No entry" "single entry" "Two array fields of different lengths"
+       $ model_version                  : chr [1:4] "1.0" "1.0" "1.0" "1.0"
+       $ model_contributors             :List of 4
+        ..$ :List of 2
+        .. ..$ :List of 2
+        .. .. ..$ name : chr "Joe Bloggs"
+        .. .. ..$ email: chr "j.bloggs@email.com"
+        .. ..$ :List of 2
+        .. .. ..$ name : chr "J Smith"
+        .. .. ..$ email: chr "j.smith@email.com"
+        ..$ :List of 2
+        .. ..$ :List of 2
+        .. .. ..$ name : chr "Joe Bloggs"
+        .. .. ..$ email: chr "j.bloggs@email.com"
+        .. ..$ :List of 2
+        .. .. ..$ name : chr "J Smith"
+        .. .. ..$ email: chr "j.smith@email.com"
+        ..$ :List of 2
+        .. ..$ :List of 2
+        .. .. ..$ name : chr "Joe Bloggs"
+        .. .. ..$ email: chr "j.bloggs@email.com"
+        .. ..$ :List of 2
+        .. .. ..$ name : chr "J Smith"
+        .. .. ..$ email: chr "j.smith@email.com"
+        ..$ :List of 2
+        .. ..$ :List of 2
+        .. .. ..$ name : chr "Joe Bloggs"
+        .. .. ..$ email: chr "j.bloggs@email.com"
+        .. ..$ :List of 2
+        .. .. ..$ name : chr "J Smith"
+        .. .. ..$ email: chr "j.smith@email.com"
+       $ website_url                    : chr [1:4] "https://team1goodmodel.website" "https://team1goodmodel.website" "https://team1goodmodel.website" "https://team1goodmodel.website"
+       $ repo_url                       : logi [1:4] NA NA NA NA
+       $ license                        : chr [1:4] "cc-by-4.0" "cc-by-4.0" "cc-by-4.0" "cc-by-4.0"
+       $ designated_model               : logi [1:4] NA NA NA NA
+       $ citation                       : logi [1:4] NA NA NA NA
+       $ team_funding                   : logi [1:4] NA NA NA NA
+       $ data_inputs                    : logi [1:4] NA NA NA NA
+       $ methods                        : logi [1:4] NA NA NA NA
+       $ methods_long                   : logi [1:4] NA NA NA NA
+       $ ensemble_of_models             : logi [1:4] NA NA NA NA
+       $ ensemble_of_hub_models         : logi [1:4] FALSE FALSE FALSE FALSE
+       $ mandatory_array_valued_metadata:List of 4
+        ..$ :List of 2
+        .. ..$ : chr "test"
+        .. ..$ : chr "test2"
+        ..$ : NULL
+        ..$ :List of 1
+        .. ..$ : chr "test"
+        ..$ :List of 2
+        .. ..$ : chr "test"
+        .. ..$ : chr "test2"
+       $ optional_array_valued_metadata :List of 4
+        ..$ : NULL
+        ..$ : NULL
+        ..$ : NULL
+        ..$ :List of 3
+        .. ..$ : chr "test3"
+        .. ..$ : chr "test4"
+        .. ..$ : chr "test5"
+       $ include_viz                    : logi [1:4] TRUE TRUE TRUE TRUE
+       $ include_ensemble               : logi [1:4] FALSE FALSE FALSE FALSE
+       $ include_eval                   : logi [1:4] TRUE TRUE TRUE TRUE
+       $ model_details                  :List of 4
+        ..$ :List of 2
+        .. ..$ methods    : chr "this the method description of the model."
+        .. ..$ data_inputs: chr "description of the data inputs"
+        ..$ :List of 2
+        .. ..$ methods    : chr "this the method description of the model."
+        .. ..$ data_inputs: chr "description of the data inputs"
+        ..$ :List of 2
+        .. ..$ methods    : chr "this the method description of the model."
+        .. ..$ data_inputs: chr "description of the data inputs"
+        ..$ :List of 2
+        .. ..$ methods    : chr "this the method description of the model."
+        .. ..$ data_inputs: chr "description of the data inputs"
+

--- a/tests/testthat/test-load_model_metadata.R
+++ b/tests/testthat/test-load_model_metadata.R
@@ -43,50 +43,68 @@ test_that("resulting tibble has team_abbr, model_abbr, and model_id_columns", {
 })
 
 test_that("Top-level array fields yield list columns, even if they are absent or length-1", {
-    hub_path <- test_path("testdata/array_hub")
+  hub_path <- test_path("testdata/array_hub")
 
-    # metadata should be loadable for one model at a time, yielding a 1-row tibble in every case 
-    # Top-level array fields should render as lists (or NA if absent)
-    individual_metadata <- purrr::map(purrr::set_names(c("no-entry", "single-entry", "multi-entry", "two-arrays")),
-               \(x) load_model_metadata(hub_path, model_ids = x))
+  # metadata should be loadable for one model at a time, yielding a 1-row tibble in every case
+  # Top-level array fields should render as lists (or NA if absent)
+  individual_metadata <- purrr::map(
+    purrr::set_names(c(
+      "no-entry",
+      "single-entry",
+      "multi-entry",
+      "two-arrays"
+    )),
+    \(x) load_model_metadata(hub_path, model_ids = x)
+  )
 
-    purrr::iwalk(individual_metadata, \(x, idx) {
-        ptype_mandatory <- if(idx == "no-entry") logical() else list()
-        ptype_optional <- if(idx == "two-arrays") list() else logical()
-        expect_s3_class(x, "tbl_df")
-        expect_shape(x, nrow = 1L)
-        expect_vector(x$mandatory_array_valued_metadata, ptype = ptype_mandatory)
-        expect_vector(x$optional_array_valued_metadata, ptype = ptype_optional)
-        expect_vector(x$model_name, ptype = character())
-    })
+  purrr::iwalk(individual_metadata, \(x, idx) {
+    ptype_mandatory <- if (idx == "no-entry") logical() else list()
+    ptype_optional <- if (idx == "two-arrays") list() else logical()
+    expect_s3_class(x, "tbl_df")
+    expect_shape(x, nrow = 1L)
+    expect_vector(x$mandatory_array_valued_metadata, ptype = ptype_mandatory)
+    expect_vector(x$optional_array_valued_metadata, ptype = ptype_optional)
+    expect_vector(x$model_name, ptype = character())
+  })
 
-    # it should be possible to load two models with different choices:
-    metadata_for_two_models <- load_model_metadata(hub_path, model_ids = c("no-entry", "two-arrays"))
-    expect_s3_class(metadata_for_two_models, "tbl_df")
-    expect_shape(metadata_for_two_models, nrow = 2L)
-    expect_vector(metadata_for_two_models$mandatory_array_valued_metadata, ptype = list())
-    expect_vector(metadata_for_two_models$optional_array_valued_metadata, ptype = list())
-    expect_vector(metadata_for_two_models$model_name, ptype = character())
+  # it should be possible to load two models with different choices:
+  metadata_for_two_models <- load_model_metadata(
+    hub_path,
+    model_ids = c("no-entry", "two-arrays")
+  )
+  expect_s3_class(metadata_for_two_models, "tbl_df")
+  expect_shape(metadata_for_two_models, nrow = 2L)
+  expect_vector(
+    metadata_for_two_models$mandatory_array_valued_metadata,
+    ptype = list()
+  )
+  expect_vector(
+    metadata_for_two_models$optional_array_valued_metadata,
+    ptype = list()
+  )
+  expect_vector(metadata_for_two_models$model_name, ptype = character())
 
-    # model metadata files with different length top-level arrays for the same key should be row-bindable
-    model_metadata <- load_model_metadata(hub_path)
-    expect_snapshot(str(model_metadata))
-    # array columns should be lists, but others should be character, etc
-    expect_vector(model_metadata$mandatory_array_valued_metadata, ptype = list())
-    expect_vector(model_metadata$optional_array_valued_metadata, ptype = list())
-    expect_vector(model_metadata$model_name, ptype = character())
-    
-    # there should be no duplicate model ids
-    expect_equal(model_metadata$model_id, unique(model_metadata$model_id))
+  # model metadata files with different length top-level arrays for the same key should be row-bindable
+  model_metadata <- load_model_metadata(hub_path)
+  expect_snapshot(str(model_metadata))
+  # array columns should be lists, but others should be character, etc
+  expect_vector(model_metadata$mandatory_array_valued_metadata, ptype = list())
+  expect_vector(model_metadata$optional_array_valued_metadata, ptype = list())
+  expect_vector(model_metadata$model_name, ptype = character())
 
-    # row-binding the single-row tibbles that result from
-    # loading models individually should yield the jointly-loaded metadata
-    # if we ensure the same row order.
-    manual_complete_metadata <- dplyr::bind_rows(individual_metadata)
-    expect_equal(dplyr::arrange(model_metadata, .data$model_id),
-                 dplyr::arrange(manual_complete_metadata, .data$model_id))
+  # there should be no duplicate model ids
+  expect_equal(model_metadata$model_id, unique(model_metadata$model_id))
+
+  # row-binding the single-row tibbles that result from
+  # loading models individually should yield the jointly-loaded metadata
+  # if we ensure the same row order.
+  manual_complete_metadata <- dplyr::bind_rows(individual_metadata)
+  expect_equal(
+    dplyr::arrange(model_metadata, .data$model_id),
+    dplyr::arrange(manual_complete_metadata, .data$model_id)
+  )
 })
-                                   
+
 # Specifying non-existent models throws an error
 test_that("Specifying models that don't provide metadata throws an error", {
   hub_path <- system.file("testhubs/simple", package = "hubUtils")

--- a/tests/testthat/test-load_model_metadata.R
+++ b/tests/testthat/test-load_model_metadata.R
@@ -42,6 +42,51 @@ test_that("resulting tibble has team_abbr, model_abbr, and model_id_columns", {
   ))
 })
 
+test_that("Top-level array fields yield list columns, even if they are absent or length-1", {
+    hub_path <- test_path("testdata/array_hub")
+
+    # metadata should be loadable for one model at a time, yielding a 1-row tibble in every case 
+    # Top-level array fields should render as lists (or NA if absent)
+    individual_metadata <- purrr::map(purrr::set_names(c("no-entry", "single-entry", "multi-entry", "two-arrays")),
+               \(x) load_model_metadata(hub_path, model_ids = x))
+
+    purrr::iwalk(individual_metadata, \(x, idx) {
+        ptype_mandatory <- if(idx == "no-entry") logical() else list()
+        ptype_optional <- if(idx == "two-arrays") list() else logical()
+        expect_s3_class(x, "tbl_df")
+        expect_shape(x, nrow = 1L)
+        expect_vector(x$mandatory_array_valued_metadata, ptype = ptype_mandatory)
+        expect_vector(x$optional_array_valued_metadata, ptype = ptype_optional)
+        expect_vector(x$model_name, ptype = character())
+    })
+
+    # it should be possible to load two models with different choices:
+    metadata_for_two_models <- load_model_metadata(hub_path, model_ids = c("no-entry", "two-arrays"))
+    expect_s3_class(metadata_for_two_models, "tbl_df")
+    expect_shape(metadata_for_two_models, nrow = 2L)
+    expect_vector(metadata_for_two_models$mandatory_array_valued_metadata, ptype = list())
+    expect_vector(metadata_for_two_models$optional_array_valued_metadata, ptype = list())
+    expect_vector(metadata_for_two_models$model_name, ptype = character())
+
+    # model metadata files with different length top-level arrays for the same key should be row-bindable
+    model_metadata <- load_model_metadata(hub_path)
+    expect_snapshot(str(model_metadata))
+    # array columns should be lists, but others should be character, etc
+    expect_vector(model_metadata$mandatory_array_valued_metadata, ptype = list())
+    expect_vector(model_metadata$optional_array_valued_metadata, ptype = list())
+    expect_vector(model_metadata$model_name, ptype = character())
+    
+    # there should be no duplicate model ids
+    expect_equal(model_metadata$model_id, unique(model_metadata$model_id))
+
+    # row-binding the single-row tibbles that result from
+    # loading models individually should yield the jointly-loaded metadata
+    # if we ensure the same row order.
+    manual_complete_metadata <- dplyr::bind_rows(individual_metadata)
+    expect_equal(dplyr::arrange(model_metadata, .data$model_id),
+                 dplyr::arrange(manual_complete_metadata, .data$model_id))
+})
+                                   
 # Specifying non-existent models throws an error
 test_that("Specifying models that don't provide metadata throws an error", {
   hub_path <- system.file("testhubs/simple", package = "hubUtils")

--- a/tests/testthat/testdata/array_hub/hub-config/admin.json
+++ b/tests/testthat/testdata/array_hub/hub-config/admin.json
@@ -1,0 +1,17 @@
+{
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/admin-schema.json",
+    "name": "Simple Forecast Hub",
+    "maintainer": "Consortium of Infectious Disease Modeling Hubs",
+    "contact": {
+        "name": "Joe Bloggs",
+        "email": "j.bloggs@cidmh.com"
+    },
+    "repository_url": "https://github.com/hubverse-org/example-simple-forecast-hub",
+    "hub_models": [{
+        "team_abbr": "simple_hub",
+        "model_abbr": "baseline",
+        "model_type": "baseline"
+    }],
+    "file_format": ["csv", "parquet", "arrow"],
+    "timezone": "US/Eastern"
+}

--- a/tests/testthat/testdata/array_hub/hub-config/model-metadata-schema.json
+++ b/tests/testthat/testdata/array_hub/hub-config/model-metadata-schema.json
@@ -1,0 +1,137 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Schema for Modeling Hub model metadata",
+    "description": "This is the schema for model metadata files, please refer to https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/wiki/Metadata for more information.",
+    "type": "object",
+    "properties": {
+        "team_name": {
+            "description": "The name of the team submitting the model",
+            "type": "string"
+        },
+        "model_name": {
+            "description": "The name of the model",
+            "type": "string"
+        },
+        "model_abbr": {
+            "description": "Abbreviated name of the model",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_+]+$",
+            "maxLength": 16
+        },
+        "model_version": {
+            "description": "Identifier of the version of the model",
+            "type": "string"
+        },
+        "model_contributors": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "affiliation": {
+                        "type": "string"
+                    },
+                    "email": {
+                        "type": "string",
+                        "format": "email"
+                    },
+                    "orcid": {
+                        "type": "string",
+                        "pattern": "^\\d{4}\\-\\d{4}\\-\\d{4}\\-[\\dX]{4}$"
+                    }
+                },
+                "additionalProperties": false,
+                "required": ["name", "affiliation", "email"]
+            }
+        },
+        "website_url": {
+            "description": "Public facing website for the model",
+            "type": "string",
+            "format": "uri"
+        },
+        "repo_url": {
+            "description": "Repository containing code for the model",
+            "type": "string",
+            "format": "uri"
+        },
+        "license": {
+            "description": "License for use of model output data",
+            "type": "string",
+            "enum": [
+                "CC0-1.0",
+                "CC-BY-4.0",
+                "CC-BY_SA-4.0",
+                "PPDL",
+                "ODC-by",
+                "ODbL",
+                "OGL-3.0"
+            ]
+        },
+        "designated_model": {
+            "description": "Team-specified indicator for whether the model should be eligible for inclusion in a Hub ensemble and public visualization. A team may designate up to two models.",
+            "type": "boolean"
+        },
+        "citation": {
+            "description": "One or more citations for this model",
+            "type": "string",
+            "examples": ["Gibson GC , Reich NG , Sheldon D. Real-time mechanistic bayesian forecasts of Covid-19 mortality. medRxiv. 2020. https://doi.org/10.1101/2020.12.22.20248736"]
+        },
+        "team_funding": {
+            "description": "Any information about funding source for the team or members of the team.",
+            "type": "string",
+            "examples": ["National Institutes of General Medical Sciences (R01GM123456). The content is solely the responsibility of the authors and does not necessarily represent the official views of NIGMS."]
+        },
+        "data_inputs": {
+            "description": "List or description of data inputs used by the model",
+            "type": "string"
+        },
+        "methods": {
+            "description": "A brief (200 char.) description of the methods used by this model",
+            "type": "string",
+            "maxLength": 200
+        },
+        "methods_long": {
+            "description": "A full description of the methods used by this model. Among other details, this should include whether spatial correlation is considered and how the model accounts for uncertainty.",
+            "type": "string"
+        },
+        "ensemble_of_models": {
+            "description": "Indicator for whether this model is an ensemble of any separate component models",
+            "type": "boolean"
+        },
+        "ensemble_of_hub_models": {
+            "description": "Indicator for whether this model is an ensemble specifically of other models submitted to this Hub",
+            "type": "boolean"
+        },
+	"mandatory_array_valued_metadata": {
+            "description": "An array of strings model metadata field for testing whether hubData::load_model_metadata handles these gracefully",
+	    "type": "array",
+	    "items": {
+		"type": "string"
+	    }
+	},
+	"optional_array_valued_metadata": {
+            "description": "Another array of strings model metadata field for testing whether hubData::load_model_metadata handles these gracefully",
+	    "type": "array",
+	    "items": {
+		"type": "string"
+	    }
+	}
+    },
+    "additionalProperties": true,
+    "required": [
+        "team_name",
+        "team_abbr",
+        "model_name",
+        "model_abbr",
+        "model_contributors",
+        "license",
+        "data_inputs",
+        "methods",
+        "methods_long",
+        "ensemble_of_models",
+        "ensemble_of_hub_models",
+        "mandatory_array_valued_metadata"
+    ]
+}

--- a/tests/testthat/testdata/array_hub/hub-config/tasks.json
+++ b/tests/testthat/testdata/array_hub/hub-config/tasks.json
@@ -1,0 +1,134 @@
+{
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json",
+    "rounds": [{
+            "round_id_from_variable": true,
+            "round_id": "origin_date",
+            "model_tasks": [{
+                "task_ids": {
+                    "origin_date": {
+                        "required": null,
+                        "optional": ["2022-10-01", "2022-10-08", "2022-10-15", "2022-10-22", "2022-10-29"]
+                    },
+                    "target": {
+                        "required": "wk inc flu hosp",
+                        "optional": null
+                    },
+                    "horizon": {
+                        "required": [1],
+                        "optional": [2, 3, 4]
+                    },
+                    "location": {
+                        "required": null,
+                        "optional": [
+                            "US",
+                            "01",
+                            "02",
+                            "04",
+                            "05",
+                            "06",
+                            "08",
+                            "09",
+                            "10",
+                            "11",
+                            "12",
+                            "13",
+                            "15",
+                            "16",
+                            "17",
+                            "18",
+                            "19",
+                            "20",
+                            "21",
+                            "22",
+                            "23",
+                            "24",
+                            "25",
+                            "26",
+                            "27",
+                            "28",
+                            "29",
+                            "30",
+                            "31",
+                            "32",
+                            "33",
+                            "34",
+                            "35",
+                            "36",
+                            "37",
+                            "38",
+                            "39",
+                            "40",
+                            "41",
+                            "42",
+                            "44",
+                            "45",
+                            "46",
+                            "47",
+                            "48",
+                            "49",
+                            "50",
+                            "51",
+                            "53",
+                            "54",
+                            "55",
+                            "56",
+                            "72",
+                            "78"
+                        ]
+                    }
+                },
+                "output_type": {
+                    "mean": {
+                        "output_type_id": {
+                            "required": ["NA"],
+                            "optional": ["NA"]
+                        },
+                        "value": {
+                            "type": "integer",
+                            "minimum": 0
+                        }
+                    },
+                    "quantile": {
+                        "output_type_id": {
+                            "required": [
+                                0.010,
+                                0.025,
+                                0.050,
+                                0.100,
+                                0.150,
+                                0.200,
+                                0.250,
+                                0.300,
+                                0.350,
+                                0.400,
+                                0.450,
+                                0.500,
+                                0.550,
+                                0.600,
+                                0.650,
+                                0.700,
+                                0.750,
+                                0.800,
+                                0.850,
+                                0.900,
+                                0.950,
+                                0.975,
+                                0.990
+                            ],
+                            "optional": null
+                        },
+                        "value": {
+                            "type": "integer",
+                            "minimum": 0
+                        }
+                    }
+                }
+            }],
+            "submissions_due": {
+                "start": -6,
+                "end": 1
+            }
+        }
+
+    ]
+}

--- a/tests/testthat/testdata/array_hub/model-metadata/multi-entry.yml
+++ b/tests/testthat/testdata/array_hub/model-metadata/multi-entry.yml
@@ -19,7 +19,7 @@ include_ensemble: false
 include_eval: true
 model_details: {
   methods: "this the method description of the model.",
-  data_inputs: "description of the data inputs"
+  data_inputs: ["description of the data inputs", "and another"]
 }
 ensemble_of_hub_models: false
-mandatory_array_valued_metadata: ["test", "test2"]
+mandatory_array_valued_metadata: ["foo"]

--- a/tests/testthat/testdata/array_hub/model-metadata/multi-entry.yml
+++ b/tests/testthat/testdata/array_hub/model-metadata/multi-entry.yml
@@ -1,0 +1,25 @@
+team_name: "Hub Coordination Team"
+model_name: "Multi entry"
+model_id: "multi-entry"
+model_version: "1.0"
+model_contributors: [
+  {
+    "name": "Joe Bloggs",
+    "email": "j.bloggs@email.com"
+  },
+  {
+    "name": "J Smith",
+    "email": "j.smith@email.com"
+  }
+]
+website_url: "https://team1goodmodel.website"
+license: "cc-by-4.0"
+include_viz: true
+include_ensemble: false
+include_eval: true
+model_details: {
+  methods: "this the method description of the model.",
+  data_inputs: "description of the data inputs"
+}
+ensemble_of_hub_models: false
+mandatory_array_valued_metadata: ["test", "test2"]

--- a/tests/testthat/testdata/array_hub/model-metadata/multi-entry.yml
+++ b/tests/testthat/testdata/array_hub/model-metadata/multi-entry.yml
@@ -19,7 +19,7 @@ include_ensemble: false
 include_eval: true
 model_details: {
   methods: "this the method description of the model.",
-  data_inputs: ["description of the data inputs", "and another"]
+  data_inputs: "description of the data inputs"
 }
 ensemble_of_hub_models: false
-mandatory_array_valued_metadata: ["foo"]
+mandatory_array_valued_metadata: ["test", "test2"]

--- a/tests/testthat/testdata/array_hub/model-metadata/no-entry.yml
+++ b/tests/testthat/testdata/array_hub/model-metadata/no-entry.yml
@@ -1,0 +1,25 @@
+team_name: "Hub Coordination Team"
+model_name: "No entry"
+model_id: "no-entry"
+model_version: "1.0"
+model_contributors: [
+  {
+    "name": "Joe Bloggs",
+    "email": "j.bloggs@email.com"
+  },
+  {
+    "name": "J Smith",
+    "email": "j.smith@email.com"
+  }
+]
+website_url: "https://team1goodmodel.website"
+license: "cc-by-4.0"
+include_viz: true
+include_ensemble: false
+include_eval: true
+model_details: {
+  methods: "this the method description of the model.",
+  data_inputs: "description of the data inputs"
+}
+ensemble_of_hub_models: false
+mandatory_array_valued_metadata:

--- a/tests/testthat/testdata/array_hub/model-metadata/single-entry.yml
+++ b/tests/testthat/testdata/array_hub/model-metadata/single-entry.yml
@@ -1,0 +1,25 @@
+team_name: "Hub Coordination Team"
+model_name: "single entry"
+model_id: "single-entry"
+model_version: "1.0"
+model_contributors: [
+  {
+    "name": "Joe Bloggs",
+    "email": "j.bloggs@email.com"
+  },
+  {
+    "name": "J Smith",
+    "email": "j.smith@email.com"
+  }
+]
+website_url: "https://team1goodmodel.website"
+license: "cc-by-4.0"
+include_viz: true
+include_ensemble: false
+include_eval: true
+model_details: {
+  methods: "this the method description of the model.",
+  data_inputs: "description of the data inputs"
+}
+ensemble_of_hub_models: false
+mandatory_array_valued_metadata: ["test"]

--- a/tests/testthat/testdata/array_hub/model-metadata/two-arrays.yml
+++ b/tests/testthat/testdata/array_hub/model-metadata/two-arrays.yml
@@ -1,0 +1,26 @@
+team_name: "Hub Coordination Team"
+model_name: "Two array fields of different lengths"
+model_id: "two-arrays"
+model_version: "1.0"
+model_contributors: [
+  {
+    "name": "Joe Bloggs",
+    "email": "j.bloggs@email.com"
+  },
+  {
+    "name": "J Smith",
+    "email": "j.smith@email.com"
+  }
+]
+website_url: "https://team1goodmodel.website"
+license: "cc-by-4.0"
+include_viz: true
+include_ensemble: false
+include_eval: true
+model_details: {
+  methods: "this the method description of the model.",
+  data_inputs: "description of the data inputs"
+}
+ensemble_of_hub_models: false
+mandatory_array_valued_metadata: ["test", "test2"]
+optional_array_valued_metadata: ["test3", "test4", "test5"]


### PR DESCRIPTION
Closes #136 and adds tests that would have identified the issue

## Notes
- Bumps minimum `testthat` to `>=3.3.0` to allow use of `expect_shape()`