### PR TITLE
Bump to development version 2.2.0.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubData
 Title: Tools for accessing and working with hubverse data
-Version: 2.2.0
+Version: 2.2.0.9000
 Authors@R: 
     c(person("Anna", "Krystalli", , "annakrystalli@googlemail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2378-4915")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# hubData (development version)
+
 # hubData 2.2.0
 
 * Fixed bug in `load_model_metadata()` that caused array-valued top-level fields in model metadata YAML files to parse incorrectly or fail to parse at all (#137). Array-valued top-level fields are now translated into list columns, per the function specification. **Note**: The bug also meant that length-1 top-level arrays parsed equivalently to top-level scalars, e.g. both `y: "x"` and `y: ["x"]` parsed as a character column `y` with value `x`. With the fix, those entries parse differently: `y: "x"` parses as a character column; `y: ["x"]` parses as a list column. Thanks @dylanhmorris.


### PR DESCRIPTION
## Summary

Post-release bump to development version `2.2.0.9000` following the v2.2.0 release.