### PR TITLE
Materialise arrow ALTREP columns in collect_hub() (#141)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # hubData (development version)
 
+* Fixed bug in `collect_hub()` that caused returned tibbles to contain arrow-ALTREP-backed columns rather than plain materialised R vectors (#141). The ALTREP views could not be safely `save()`d, `serialize()`d, or sent to parallel workers in R sessions without `arrow` installed, silently corrupting columns (most came back length-0). `collect_hub()` now sets `arrow.use_altrep = FALSE` for the duration of the call, restoring the long-standing `dplyr::collect()` contract of materialising into plain in-memory R vectors. Users who want lazy / ALTREP-friendly access can continue to use `connect_hub()` and work with the arrow dataset directly.
+
 # hubData 2.2.0
 
 * Fixed bug in `load_model_metadata()` that caused array-valued top-level fields in model metadata YAML files to parse incorrectly or fail to parse at all (#137). Array-valued top-level fields are now translated into list columns, per the function specification. **Note**: The bug also meant that length-1 top-level arrays parsed equivalently to top-level scalars, e.g. both `y: "x"` and `y: ["x"]` parsed as a character column `y` with value `x`. With the fix, those entries parse differently: `y: "x"` parses as a character column; `y: ["x"]` parses as a list column. Thanks @dylanhmorris.

--- a/R/collect_hub.R
+++ b/R/collect_hub.R
@@ -29,6 +29,12 @@ collect_hub <- function(x, silent = FALSE, ...) {
     return(NULL)
   }
 
+  # Force arrow to materialise columns into plain R vectors rather than
+  # ALTREP views, so the result can be safely save()d / serialize()d through
+  # R sessions without arrow installed (see hubverse-org/hubData#141).
+  old_opts <- options(arrow.use_altrep = FALSE)
+  on.exit(options(old_opts), add = TRUE)
+
   tbl <- tryCatch(
     dplyr::collect(x),
     error = function(e) {

--- a/tests/testthat/test-collect_hub.R
+++ b/tests/testthat/test-collect_hub.R
@@ -59,6 +59,39 @@ test_that("collect_hub works on local simple forecasting hub", {
 })
 
 
+test_that("collect_hub() returns plain (non-ALTREP) R vectors", {
+  # Guard against arrow returning ALTREP-backed columns from dplyr::collect(),
+  # which silently corrupt save() / serialize() in R sessions without arrow
+  # installed (hubverse-org/hubData#141). arrow's own is_arrow_altrep()
+  # detector is unexported in recent arrow versions, so we use the SEXP-level
+  # inspect output (the canonical verification noted in the issue): ALTREP
+  # views are tagged with an "arrow::array_*" class identifier.
+  is_arrow_altrep <- function(x) {
+    any(grepl("arrow::array_", utils::capture.output(.Internal(inspect(x))),
+              fixed = TRUE))
+  }
+
+  hub_path <- system.file("testhubs/simple", package = "hubUtils")
+  hub_con <- connect_hub(hub_path)
+  out <- collect_hub(hub_con)
+
+  for (col in names(out)) {
+    expect_false(
+      is_arrow_altrep(out[[col]]),
+      info = sprintf("column %s is arrow-ALTREP", col)
+    )
+  }
+})
+
+test_that("collect_hub() does not leak arrow.use_altrep option", {
+  hub_path <- system.file("testhubs/simple", package = "hubUtils")
+  hub_con <- connect_hub(hub_path)
+
+  before <- getOption("arrow.use_altrep")
+  collect_hub(hub_con)
+  expect_identical(getOption("arrow.use_altrep"), before)
+})
+
 test_that("collect_hub returns NULL with warning when model output folder is empty", {
   hub_path <- system.file("testhubs/empty", package = "hubUtils")
   hub_con <- suppressWarnings(connect_hub(hub_path))

--- a/tests/testthat/test-collect_hub.R
+++ b/tests/testthat/test-collect_hub.R
@@ -67,8 +67,11 @@ test_that("collect_hub() returns plain (non-ALTREP) R vectors", {
   # inspect output (the canonical verification noted in the issue): ALTREP
   # views are tagged with an "arrow::array_*" class identifier.
   is_arrow_altrep <- function(x) {
-    any(grepl("arrow::array_", utils::capture.output(.Internal(inspect(x))),
-              fixed = TRUE))
+    any(grepl(
+      "arrow::array_",
+      utils::capture.output(.Internal(inspect(x))),
+      fixed = TRUE
+    ))
   }
 
   hub_path <- system.file("testhubs/simple", package = "hubUtils")


### PR DESCRIPTION
Closes #141.

## Summary
- `collect_hub()` now wraps its `dplyr::collect()` call with `options(arrow.use_altrep = FALSE)` (restored on exit via `on.exit()`), so the returned tibble contains plain materialised R vectors rather than arrow-ALTREP views.
- This restores the long-standing `dplyr::collect()` contract — "pull the lazy thing into plain in-memory R" — that arrow silently weakened from 5.0.0 onward. ALTREP-backed columns could not be `save()`d / `serialize()`d / sent to parallel workers in R sessions without `arrow` installed (most came back length-0), which is the bug that bit `hubverse-org/hubExamples` and downstream packages.
- Users who want lazy / ALTREP-friendly access still have a clean route via `connect_hub()` working on the arrow dataset directly.

## Implementation notes
- Used base R `options()` + `on.exit()` rather than `withr::with_options()` to avoid pulling `withr` into `Imports` for a two-line idiom. The semantics are identical: option restored on normal *or* error exit.
- No `arrow` version guard needed — `arrow.use_altrep` has existed since arrow 5.0.0, and the package already requires `arrow (>= 17.0.0)`.

## Tests
- Added `collect_hub() returns plain (non-ALTREP) R vectors` — uses `.Internal(inspect())` capture and greps for the `arrow::array_*` ALTREP class identifier (arrow's `is_arrow_altrep()` detector is unexported in arrow ≥ 23, but the inspect output is the canonical SEXP-level verification noted in #141).
- Added `collect_hub() does not leak arrow.use_altrep option` — confirms the `on.exit()` restoration works.
- Verified the new detector flags `TRUE` against pre-fix behaviour (option forced `TRUE`) and `FALSE` against the fix, so the test is a real regression guard.

## Test plan
- [x] `devtools::test()` — 461 pass, 0 fail (one pre-existing warning in an unrelated oracle-schema test).
- [x] `lintr::lint_package()` with project `.lintr` — 0 lints.
- [ ] CI: R-CMD-check, lint, coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)