### PR TITLE
Release hubData 2.2.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubData
 Title: Tools for accessing and working with hubverse data
-Version: 2.2.0.9000
+Version: 2.2.1
 Authors@R: 
     c(person("Anna", "Krystalli", , "annakrystalli@googlemail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2378-4915")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# hubData (development version)
+# hubData 2.2.1
 
 * Fixed bug in `collect_hub()` that caused returned tibbles to contain arrow-ALTREP-backed columns rather than plain materialised R vectors (#141). The ALTREP views could not be safely `save()`d, `serialize()`d, or sent to parallel workers in R sessions without `arrow` installed, silently corrupting columns (most came back length-0). `collect_hub()` now sets `arrow.use_altrep = FALSE` for the duration of the call, restoring the long-standing `dplyr::collect()` contract of materialising into plain in-memory R vectors. Users who want lazy / ALTREP-friendly access can continue to use `connect_hub()` and work with the arrow dataset directly.
 


### PR DESCRIPTION
## Summary

Patch release with a single bug fix:

* Fixed bug in `collect_hub()` that caused returned tibbles to contain arrow-ALTREP-backed columns rather than plain materialised R vectors (#141). The ALTREP views could not be safely `save()`d, `serialize()`d, or sent to parallel workers in R sessions without `arrow` installed, silently corrupting columns (most came back length-0). `collect_hub()` now sets `arrow.use_altrep = FALSE` for the duration of the call, restoring the long-standing `dplyr::collect()` contract of materialising into plain in-memory R vectors. Users who want lazy / ALTREP-friendly access can continue to use `connect_hub()` and work with the arrow dataset directly.