### PR TITLE
Read parquet on cloud hubs with non-parquet config format (#148)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # hubData (development version)
 
+* Fixed bug where `connect_hub()` returned an empty connection (with only a "No files of file format found" warning) for cloud (S3) hubs whose `admin.json` declares a non-parquet submission format such as `csv` (#148). The hubverse cloud sync always writes `model-output/` to parquet on S3, regardless of the declared submission format, so `connect_hub()` now also accepts parquet on S3 when `file_format` is not supplied. Local hubs are unaffected, and hubs that genuinely store the declared format on S3 continue to read exactly as before.
+
 # hubData 2.2.1
 
 * Fixed bug in `collect_hub()` that caused returned tibbles to contain arrow-ALTREP-backed columns rather than plain materialised R vectors (#141). The ALTREP views could not be safely `save()`d, `serialize()`d, or sent to parallel workers in R sessions without `arrow` installed, silently corrupting columns (most came back length-0). `collect_hub()` now sets `arrow.use_altrep = FALSE` for the duration of the call, restoring the long-standing `dplyr::collect()` contract of materialising into plain in-memory R vectors. Users who want lazy / ALTREP-friendly access can continue to use `connect_hub()` and work with the arrow dataset directly.

--- a/R/connect_hub.R
+++ b/R/connect_hub.R
@@ -268,6 +268,10 @@ connect_hub.SubTreeFileSystem <- function(
   if (missing(file_format)) {
     file_format <- rlang::missing_arg()
     file_format <- get_file_format(config_admin, file_format)
+    # The hubverse cloud sync pipeline always writes `model-output/` to parquet
+    # on S3, regardless of the submission format(s) declared in admin.json, so
+    # accept parquet alongside the config value.
+    file_format <- union(file_format, "parquet")
   } else {
     file_format <- rlang::arg_match(file_format, multiple = TRUE)
   }

--- a/tests/testthat/test-hub-connection.R
+++ b/tests/testthat/test-hub-connection.R
@@ -682,6 +682,38 @@ test_that("connect_hub works on parquet-only hub when skip_checks is TRUE", {
   )
 })
 
+test_that("connect_hub reads parquet on cloud hub with non-parquet config format", {
+  # Regression test for #148: the hubverse cloud sync always writes
+  # model-output to parquet on S3, regardless of the submission format(s)
+  # declared in admin.json. `example-complex-forecast-hub` declares
+  # file_format = ["csv"] (cloud.enabled = TRUE) but stores parquet on S3. A
+  # default connect_hub() must still read the data, rather than returning an
+  # empty connection with a "No files of file format 'csv' found" warning.
+  hub_path <- s3_bucket("example-complex-forecast-hub")
+
+  expect_no_warning(hub_con <- connect_hub(hub_path))
+
+  # config-declared "csv" is dropped by check_file_format() (no csv on S3) and
+  # the appended "parquet" is what actually gets opened.
+  expect_equal(
+    dimnames(attr(hub_con, "file_format"))[[2]],
+    "parquet"
+  )
+  expect_equal(
+    attr(hub_con, "file_system"),
+    "S3FileSystem"
+  )
+
+  # data is actually readable, not an empty connection
+  expect_gt(
+    hub_con |>
+      head(5) |>
+      dplyr::collect() |>
+      nrow(),
+    0L
+  )
+})
+
 
 test_that("connect_hub & connect_model_output fail correctly", {
   expect_snapshot(connect_hub("random/hub/path"), error = TRUE)


### PR DESCRIPTION
Closes #148.

## Problem

`connect_hub()` against a cloud (S3) hub returned an **empty connection with no error** when the hub's `admin.json` declared a non-parquet submission format (e.g. `csv`). `admin.json$file_format` describes what submitters **upload**, not what is **stored on S3** — the hubverse cloud sync always writes `model-output/` to parquet regardless of the declared submission format, so the config-driven format inference pointed at the wrong format and `check_file_format()` found nothing readable.

## Fix

In `connect_hub.SubTreeFileSystem` only, when `file_format` is not supplied, **append** `parquet` to the config-derived formats via `union()` rather than replacing them.

- **Self-cleaning** — `check_file_format()` intersects the requested formats with the files actually present, so the appended `parquet` is dropped when none is on S3. A hubverse cloud hub (config `csv`, parquet on S3) reads parquet with no warning; a plain csv-on-S3 hub reads csv exactly as before.
- **Unconditional**, not gated on `cloud.enabled` — the parquet on S3 is a durable fact once synced, and the append is harmless when no parquet is present.
- **Local hubs untouched** — the change lives only in the `.SubTreeFileSystem` method.
- **Config stays authoritative** for every format except the one parquet exception we own.

## Testing

- Added a regression test against `example-complex-forecast-hub` (declares `file_format = ["csv"]`, `cloud.enabled = true`, stores parquet on S3): a default `connect_hub()` emits no warning, resolves `file_format` to `parquet`, and reads data.
- `NEWS.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)