### PR TITLE
Bump to development version 2.2.2.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubData
 Title: Tools for accessing and working with hubverse data
-Version: 2.2.2
+Version: 2.2.2.9000
 Authors@R: 
     c(person("Anna", "Krystalli", , "annakrystalli@googlemail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2378-4915")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# hubData (development version)
+
 # hubData 2.2.2
 
 * Fixed bug where `connect_hub()` returned an empty connection (with only a "No files of file format found" warning) for cloud (S3) hubs whose `admin.json` declares a non-parquet submission format such as `csv` (#148). The hubverse cloud sync always writes `model-output/` to parquet on S3, regardless of the declared submission format, so `connect_hub()` now also accepts parquet on S3 when `file_format` is not supplied. Local hubs are unaffected, and hubs that genuinely store the declared format on S3 continue to read exactly as before.


### PR DESCRIPTION
Post-release bump to development version `2.2.2.9000` following the hubData 2.2.2 release.